### PR TITLE
fix: remove helper function `_normalize_pattern`

### DIFF
--- a/src/gitingest/query_parser.py
+++ b/src/gitingest/query_parser.py
@@ -18,7 +18,6 @@ from gitingest.utils.query_parser_utils import (
     _get_user_and_repo_from_path,
     _is_valid_git_commit_hash,
     _is_valid_pattern,
-    _normalize_pattern,
     _validate_host,
     _validate_url_scheme,
 )
@@ -311,7 +310,7 @@ def _parse_patterns(pattern: set[str] | str) -> set[str]:
         if not _is_valid_pattern(p):
             raise InvalidPatternError(p)
 
-    return {_normalize_pattern(p) for p in parsed_patterns}
+    return parsed_patterns
 
 
 def _parse_local_dir_path(path_str: str) -> IngestionQuery:

--- a/src/gitingest/utils/query_parser_utils.py
+++ b/src/gitingest/utils/query_parser_utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import string
 
 HEX_DIGITS: set[str] = set(string.hexdigits)
@@ -150,26 +149,3 @@ def _get_user_and_repo_from_path(path: str) -> tuple[str, str]:
         msg = f"Invalid repository URL '{path}'"
         raise ValueError(msg)
     return path_parts[0], path_parts[1]
-
-
-def _normalize_pattern(pattern: str) -> str:
-    """Normalize the given pattern by removing leading separators and appending a wildcard.
-
-    This function processes the pattern string by stripping leading directory separators
-    and appending a wildcard (``*``) if the pattern ends with a separator.
-
-    Parameters
-    ----------
-    pattern : str
-        The pattern to normalize.
-
-    Returns
-    -------
-    str
-        The normalized pattern.
-
-    """
-    pattern = pattern.lstrip(os.sep)
-    if pattern.endswith(os.sep):
-        pattern += "*"
-    return pattern


### PR DESCRIPTION
This PR removes the helper function `_normalize_pattern` (and its use inside `_parse_patterns`)


## Before

* `gitingest -e "*/test_*"`

```txt
    ├── tests/
    │   ├── __init__.py
    │   ├── conftest.py
    │   ├── .pylintrc
    │   └── query_parser/
    │       ├── __init__.py
    │       ├── test_git_host_agnostic.py
    │       └── test_query_parser.py
```


* `gitingest -e "**/test_*"`
* `gitingest -e "/test_*"`

```txt
    ├── tests/
    │   ├── __init__.py
    │   ├── conftest.py
    │   ├── .pylintrc
    │   └── query_parser/
    │       └── __init__.py
```



## Now:

* `gitingest -e "*/test_*"`: Same behaviour
* `gitingest -e "**/test_*"`: Same behaviour



* `gitingest -e "/test_*"`: Excludes no tests (matches only at project root)
```txt
    ├── tests/
    │   ├── __init__.py
    │   ├── conftest.py
    │   ├── test_cli.py
    │   ├── test_clone.py
    │   ├── test_flow_integration.py
    │   ├── test_git_utils.py
    │   ├── test_gitignore_feature.py
    │   ├── test_ingestion.py
    │   ├── test_notebook_utils.py
    │   ├── .pylintrc
    │   └── query_parser/
    │       ├── __init__.py
    │       ├── test_git_host_agnostic.py
    │       └── test_query_parser.py
```