### PR TITLE
chore: replace org name in repo urls 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you ever get stuck, reach out on [Discord](https://discord.com/invite/zerRaGK
 ## How to Contribute (non-technical)
 
 - **Create an Issue** – found a bug or have a feature idea?
-  [Open an issue](https://github.com/cyclotruc/gitingest/issues/new).
+  [Open an issue](https://github.com/coderamp-labs/gitingest/issues/new).
 - **Spread the Word** – tweet, blog, or tell a friend.
 - **Use Gitingest** – real-world usage gives the best feedback. File issues or ping us on [Discord](https://discord.com/invite/zerRaGK9EC) with anything you notice.
 
@@ -23,7 +23,7 @@ If you ever get stuck, reach out on [Discord](https://discord.com/invite/zerRaGK
 2. **Clone** your fork:
 
    ```bash
-   git clone https://github.com/cyclotruc/gitingest.git
+   git clone https://github.com/coderamp-labs/gitingest.git
    cd gitingest
    ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir --upgrade pip \
 
 # Stage 2: Runtime image
 FROM python:3.13-slim
-LABEL org.opencontainers.image.source="https://github.com/cyclotruc/gitingest"
+LABEL org.opencontainers.image.source="https://github.com/coderamp-labs/gitingest"
 
 # Minimal runtime utilities
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gitingest
 
-[![Screenshot of Gitingest front page](https://raw.githubusercontent.com/cyclotruc/gitingest/refs/heads/main/docs/frontpage.png)](https://gitingest.com)
+[![Screenshot of Gitingest front page](https://raw.githubusercontent.com/coderamp-labs/gitingest/refs/heads/main/docs/frontpage.png)](https://gitingest.com)
 
 <!-- Badges -->
 <!-- markdownlint-disable MD033 -->
@@ -10,13 +10,13 @@
   <a href="https://pypi.org/project/gitingest"><img src="https://img.shields.io/pypi/pyversions/gitingest.svg" alt="Python Versions"></a>
   <br>
   <!-- row 2 — quality & community -->
-  <a href="https://github.com/cyclotruc/gitingest/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/cyclotruc/gitingest/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://github.com/coderamp-labs/gitingest/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/coderamp-labs/gitingest/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
-  <a href="https://scorecard.dev/viewer/?uri=github.com/cyclotruc/gitingest"><img src="https://api.scorecard.dev/projects/github.com/cyclotruc/gitingest/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/coderamp-labs/gitingest"><img src="https://api.scorecard.dev/projects/github.com/coderamp-labs/gitingest/badge" alt="OpenSSF Scorecard"></a>
   <br>
-  <a href="https://github.com/cyclotruc/gitingest/blob/main/LICENSE"><img src="https://img.shields.io/github/license/cyclotruc/gitingest.svg" alt="License"></a>
+  <a href="https://github.com/coderamp-labs/gitingest/blob/main/LICENSE"><img src="https://img.shields.io/github/license/coderamp-labs/gitingest.svg" alt="License"></a>
   <a href="https://pepy.tech/project/gitingest"><img src="https://pepy.tech/badge/gitingest" alt="Downloads"></a>
-  <a href="https://github.com/cyclotruc/gitingest"><img src="https://img.shields.io/github/stars/cyclotruc/gitingest" alt="GitHub Stars"></a>
+  <a href="https://github.com/coderamp-labs/gitingest"><img src="https://img.shields.io/github/stars/coderamp-labs/gitingest" alt="GitHub Stars"></a>
   <a href="https://discord.com/invite/zerRaGK9EC"><img src="https://img.shields.io/badge/Discord-Join_chat-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <br>
   <a href="https://trendshift.io/repositories/13519"><img src="https://trendshift.io/api/badge/repositories/13519" alt="Trendshift" height="50"></a>
@@ -31,14 +31,14 @@ You can also replace `hub` with `ingest` in any GitHub URL to access the corresp
 [gitingest.com](https://gitingest.com) · [Chrome Extension](https://chromewebstore.google.com/detail/adfjahbijlkjfoicpjkhjicpjpjfaood) · [Firefox Add-on](https://addons.mozilla.org/firefox/addon/gitingest)
 
 <!-- Languages -->
-[Deutsch](https://www.readme-i18n.com/cyclotruc/gitingest?lang=de) |
-[Español](https://www.readme-i18n.com/cyclotruc/gitingest?lang=es) |
-[Français](https://www.readme-i18n.com/cyclotruc/gitingest?lang=fr) |
-[日本語](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ja) |
-[한국어](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ko) |
-[Português](https://www.readme-i18n.com/cyclotruc/gitingest?lang=pt) |
-[Русский](https://www.readme-i18n.com/cyclotruc/gitingest?lang=ru) |
-[中文](https://www.readme-i18n.com/cyclotruc/gitingest?lang=zh)
+[Deutsch](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=de) |
+[Español](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=es) |
+[Français](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=fr) |
+[日本語](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=ja) |
+[한국어](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=ko) |
+[Português](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=pt) |
+[Русский](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=ru) |
+[中文](https://www.readme-i18n.com/coderamp-labs/gitingest?lang=zh)
 
 ## 🚀 Features
 
@@ -107,10 +107,10 @@ The `gitingest` command line tool allows you to analyze codebases and create a t
 gitingest /path/to/directory
 
 # From URL
-gitingest https://github.com/cyclotruc/gitingest
+gitingest https://github.com/coderamp-labs/gitingest
 
 # or from specific subdirectory
-gitingest https://github.com/cyclotruc/gitingest/tree/main/src/gitingest/utils
+gitingest https://github.com/coderamp-labs/gitingest/tree/main/src/gitingest/utils
 ```
 
 For private repositories, use the `--token/-t` option.
@@ -150,10 +150,10 @@ from gitingest import ingest
 summary, tree, content = ingest("path/to/directory")
 
 # or from URL
-summary, tree, content = ingest("https://github.com/cyclotruc/gitingest")
+summary, tree, content = ingest("https://github.com/coderamp-labs/gitingest")
 
 # or from a specific subdirectory
-summary, tree, content = ingest("https://github.com/cyclotruc/gitingest/tree/main/src/gitingest/utils")
+summary, tree, content = ingest("https://github.com/coderamp-labs/gitingest/tree/main/src/gitingest/utils")
 ```
 
 For private repositories, you can pass a token:
@@ -220,9 +220,9 @@ If you are hosting it on a domain, you can specify the allowed hostnames via env
 
 ### Non-technical ways to contribute
 
-- **Create an Issue**: If you find a bug or have an idea for a new feature, please [create an issue](https://github.com/cyclotruc/gitingest/issues/new) on GitHub. This will help us track and prioritize your request.
+- **Create an Issue**: If you find a bug or have an idea for a new feature, please [create an issue](https://github.com/coderamp-labs/gitingest/issues/new) on GitHub. This will help us track and prioritize your request.
 - **Spread the Word**: If you like Gitingest, please share it with your friends, colleagues, and on social media. This will help us grow the community and make Gitingest even better.
-- **Use Gitingest**: The best feedback comes from real-world usage! If you encounter any issues or have ideas for improvement, please let us know by [creating an issue](https://github.com/cyclotruc/gitingest/issues/new) on GitHub or by reaching out to us on [Discord](https://discord.com/invite/zerRaGK9EC).
+- **Use Gitingest**: The best feedback comes from real-world usage! If you encounter any issues or have ideas for improvement, please let us know by [creating an issue](https://github.com/coderamp-labs/gitingest/issues/new) on GitHub or by reaching out to us on [Discord](https://discord.com/invite/zerRaGK9EC).
 
 ### Technical ways to contribute
 
@@ -242,4 +242,4 @@ Check out the NPM alternative 📦 Repomix: <https://github.com/yamadashy/repomi
 
 ## 🚀 Project Growth
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cyclotruc/gitingest&type=Date)](https://star-history.com/#cyclotruc/gitingest&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=coderamp-labs/gitingest&type=Date)](https://star-history.com/#coderamp-labs/gitingest&Date)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ gitingest = "gitingest.__main__:main"
 
 [project.urls]
 homepage = "https://gitingest.com"
-github = "https://github.com/cyclotruc/gitingest"
+github = "https://github.com/coderamp-labs/gitingest"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/src/server/server_config.py
+++ b/src/server/server_config.py
@@ -12,7 +12,7 @@ MAX_FILE_SIZE_KB: int = 100 * 1024  # 100 MB
 MAX_SLIDER_POSITION: int = 500  # Maximum slider position
 
 EXAMPLE_REPOS: list[dict[str, str]] = [
-    {"name": "Gitingest", "url": "https://github.com/cyclotruc/gitingest"},
+    {"name": "Gitingest", "url": "https://github.com/coderamp-labs/gitingest"},
     {"name": "FastAPI", "url": "https://github.com/tiangolo/fastapi"},
     {"name": "Flask", "url": "https://github.com/pallets/flask"},
     {"name": "Excalidraw", "url": "https://github.com/excalidraw/excalidraw"},

--- a/src/server/templates/components/navbar.jinja
+++ b/src/server/templates/components/navbar.jinja
@@ -17,7 +17,7 @@
                 </a>
                 {# GitHub link #}
                 <div class="flex items-center gap-2">
-                    <a href="https://github.com/cyclotruc/gitingest"
+                    <a href="https://github.com/coderamp-labs/gitingest"
                        target="_blank"
                        rel="noopener noreferrer"
                        class="link-bounce flex items-center gap-1.5 text-gray-900">

--- a/src/static/js/navbar.js
+++ b/src/static/js/navbar.js
@@ -7,7 +7,7 @@ function formatStarCount(count) {
 
 async function fetchGitHubStars() {
     try {
-        const res = await fetch('https://api.github.com/repos/cyclotruc/gitingest');
+        const res = await fetch('https://api.github.com/repos/coderamp-labs/gitingest');
 
         if (!res.ok) {throw new Error(`${res.status} ${res.statusText}`);}
         const data = await res.json();

--- a/src/static/llms.txt
+++ b/src/static/llms.txt
@@ -355,7 +355,7 @@ def ingest_with_token_rotation(repo_url: str, token_manager):
 ---
 ## 7. Support & Resources for AI Developers
 * **Web UI official instance**: https://gitingest.com
-* **GitHub Repository**: https://github.com/cyclotruc/gitingest
+* **GitHub Repository**: https://github.com/coderamp-labs/gitingest
 * **Python Package**: https://pypi.org/project/gitingest/
 * **Community Support**: https://discord.gg/zerRaGK9EC
 

--- a/src/static/robots.txt
+++ b/src/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 Allow: /api/
-Allow: /cyclotruc/gitingest/
+Allow: /coderamp-labs/gitingest/

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -233,7 +233,7 @@ async def test_clone_specific_branch(tmp_path: Path) -> None:
     When ``clone_repo`` is called,
     Then the repository should be cloned and checked out at that branch.
     """
-    repo_url = "https://github.com/cyclotruc/gitingest.git"
+    repo_url = "https://github.com/coderamp-labs/gitingest.git"
     branch_name = "main"
     local_path = tmp_path / "gitingest"
     clone_config = CloneConfig(url=repo_url, local_path=str(local_path), branch=branch_name)


### PR DESCRIPTION
This PR updates links accross the codebase from `cyclotruc/gitingest` to `coderamp-labs/gitingest` 