### PR TITLE
docs: add GitHub Issue Form for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -100,10 +100,10 @@ body:
       default: 0
       options:
         - "Select one..."
+        - Not relevant (Web UI)
         - macOS
         - Windows
         - Linux
-        - Not relevant (Web UI)
     validations:
       required: true
 
@@ -114,12 +114,12 @@ body:
       default: 0
       options:
         - "Select one..."
+        - Not relevant (CLI / PyPI)
         - Chrome
         - Firefox
         - Safari
         - Edge
         - Other (specify below)
-        - Not relevant (CLI / PyPI)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -107,6 +107,28 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser (Web UI only)
+      default: 0
+      options:
+        - "Select one..."
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - Other (specify below)
+        - Not relevant (CLI / PyPI)
+    validations:
+      required: true
+
+  - type: input
+    id: browser_other
+    attributes:
+      label: Other browser
+      placeholder: If you selected "Other", please specify the browser here.
+
   - type: input
     id: gitingest_version
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,159 @@
+name: Bug report 🐞
+description: Report a bug or internal server error when using Gitingest
+title: "(bug): "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! :lady_beetle:
+
+        Please fill out the following details to help us reproduce and fix the issue. :point_down:
+
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Which interface did you use?
+      default: 0
+      options:
+        - "Select one..."
+        - Web UI
+        - CLI
+        - PyPI package
+    validations:
+      required: true
+
+  - type: input
+    id: repo_url
+    attributes:
+      label: Repository URL (if public)
+      placeholder: e.g., https://github.com/<username>/<repo>/commit_branch_or_tag/blob_or_tree/subdir
+
+  - type: dropdown
+    id: git_host
+    attributes:
+      label: Git host
+      description: The Git host of the repository.
+      default: 0
+      options:
+        - "Select one..."
+        - GitHub (github.com)
+        - GitLab (gitlab.com)
+        - Bitbucket (bitbucket.org)
+        - Gitea (gitea.com)
+        - Codeberg (codeberg.org)
+        - Gist (gist.github.com)
+        - Kaggle (kaggle.com)
+        - GitHub Enterprise (github.company.com)
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: input
+    id: git_host_other
+    attributes:
+      label: Other Git host
+      placeholder: If you selected "Other", please specify the Git host here.
+
+  - type: dropdown
+    id: repo_visibility
+    attributes:
+      label: Repository visibility
+      default: 0
+      options:
+        - "Select one..."
+        - public
+        - private
+    validations:
+      required: true
+
+  - type: dropdown
+    id: revision
+    attributes:
+      label: Commit, branch, or tag
+      default: 0
+      options:
+        - "Select one..."
+        - default branch
+        - commit
+        - branch
+        - tag
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ingest_scope
+    attributes:
+      label: Did you ingest the full repository or a subdirectory?
+      default: 0
+      options:
+        - "Select one..."
+        - full repository
+        - subdirectory
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      default: 0
+      options:
+        - "Select one..."
+        - macOS
+        - Windows
+        - Linux
+        - Not relevant (Web UI)
+    validations:
+      required: true
+
+  - type: input
+    id: gitingest_version
+    attributes:
+      label: Gitingest version
+      placeholder: e.g., v0.1.5
+      description: Not required if you used the Web UI.
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      placeholder: e.g., 3.11.5
+      description: Not required if you used the Web UI.
+
+  - type: textarea
+    id: bug_description
+    attributes:
+      label: Bug description
+      placeholder: Describe the bug here.
+      description: A detailed but concise description of the bug.
+    validations:
+      required: true
+
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: Include the exact commands or actions that led to the error.
+      description: Include the exact commands or actions that led to the error *(if relevant)*.
+      render: shell
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      placeholder: Describe what you expected to happen.
+      description: Describe what you expected to happen *(if relevant)*.
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: Paste the full error message or stack trace here.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context, logs, or screenshots
+      placeholder: Add any other context, links, or screenshots about the issue here.


### PR DESCRIPTION
Adds a YAML-based **GitHub Issue Form** (`.github/ISSUE_TEMPLATE/bug_report.yml`) for **bug reports**.

* Collects key details up front – interface (Web UI / CLI / PyPI), repo URL, host, revision, OS, versions, steps to reproduce, etc.
* Addresses part of https://github.com/coderamp-labs/gitingest/issues/359
* No other code or docs touched.
