### PR TITLE
ci(codecov): turn off PR comments & annotations

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,3 @@
+comment: false
+github_checks:
+  annotations: false


### PR DESCRIPTION
Adds a `.codecov.yml` that sets `comment: false` and disables GitHub-checks annotations. This keeps Codecov reporting intact while cleaning up noisy balloons and bot comments on pull requests.
