### PR TITLE
fix: gitignore and gitingestignore files are now correctly processed …

### DIFF
--- a/src/gitingest/entrypoint.py
+++ b/src/gitingest/entrypoint.py
@@ -83,15 +83,14 @@ async def ingest_async(
         token=token,
     )
 
-    if not include_gitignored:
-        _apply_gitignores(query)
-
     if query.url:
         _override_branch_and_tag(query, branch=branch, tag=tag)
 
     query.include_submodules = include_submodules
 
     async with _clone_repo_if_remote(query, token=token):
+        if not include_gitignored:
+            _apply_gitignores(query)
         summary, tree, content = ingest_query(query)
         await _write_output(tree, content=content, target=output)
         return summary, tree, content

--- a/src/gitingest/utils/ignore_patterns.py
+++ b/src/gitingest/utils/ignore_patterns.py
@@ -194,7 +194,6 @@ def load_ignore_patterns(root: Path, filename: str) -> set[str]:
     for ignore_file in root.rglob(filename):
         if ignore_file.is_file():
             patterns.update(_parse_ignore_file(ignore_file, root))
-
     return patterns
 
 


### PR DESCRIPTION
Closes #391

## Issue

gitignore and gitingestignore patterns are not used.

## Solution

We tried to read and include the templates before the clone was made. We process these files once the clone is complete.