### PR TITLE
fix: Potential fix for code scanning alert no. 77: Uncontrolled data used in path expression

### DIFF
--- a/src/gitingest/query_parser.py
+++ b/src/gitingest/query_parser.py
@@ -327,7 +327,10 @@ def _parse_local_dir_path(path_str: str) -> IngestionQuery:
         A dictionary containing the parsed details of the file path.
 
     """
+    root_path = TMP_BASE_PATH.resolve()
     path_obj = Path(path_str).resolve()
+    if os.path.commonpath([root_path, path_obj]) != str(root_path):
+        raise InvalidPatternError(f"Path {path_str} escapes the allowed root directory.")
     slug = path_obj.name if path_str == "." else path_str.strip("/")
     return IngestionQuery(local_path=path_obj, slug=slug, id=str(uuid.uuid4()))
 

--- a/src/gitingest/query_parser.py
+++ b/src/gitingest/query_parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import uuid
 import warnings
@@ -326,11 +327,17 @@ def _parse_local_dir_path(path_str: str) -> IngestionQuery:
     IngestionQuery
         A dictionary containing the parsed details of the file path.
 
+    Raises
+    ------
+    InvalidPatternError
+        If the path escapes the allowed root directory.
+
     """
     root_path = TMP_BASE_PATH.resolve()
     path_obj = Path(path_str).resolve()
     if os.path.commonpath([root_path, path_obj]) != str(root_path):
-        raise InvalidPatternError(f"Path {path_str} escapes the allowed root directory.")
+        msg = f"Path {path_str} escapes the allowed root directory."
+        raise InvalidPatternError(msg)
     slug = path_obj.name if path_str == "." else path_str.strip("/")
     return IngestionQuery(local_path=path_obj, slug=slug, id=str(uuid.uuid4()))
 


### PR DESCRIPTION
Potential fix for [https://github.com/coderamp-labs/gitingest/security/code-scanning/77](https://github.com/coderamp-labs/gitingest/security/code-scanning/77)

To address this issue, the `_parse_local_dir_path` function needs to validate the `path_str` input to ensure it stays within a predefined safe root directory. 

1. **Validation Strategy**:
   - Define a safe root directory (e.g., `TMP_BASE_PATH`).
   - Normalize the path using `Path.resolve()` and ensure the resulting path is a subpath of the safe root directory.

2. **Implementation**:
   - Use `os.path.commonpath` to compare the normalized path to the safe root directory.
   - Raise an exception if the path escapes the root directory.

3. **Changes Required**:
   - Modify `_parse_local_dir_path` in `src/gitingest/query_parser.py` to include validation logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
