### PR TITLE
ci: add workflow to label PRs needing rebase

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -1,0 +1,29 @@
+name: PR Needs Rebase
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-rebase-needed:
+    runs-on: ubuntu-latest
+    if: github.repository == 'coderamp-labs/gitingest'
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: 'rebase needed :construction:'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          commentOnClean: This pull request has resolved merge conflicts and is ready for review.
+          commentOnDirty: This pull request has merge conflicts that must be resolved before it can be merged.
+          retryMax: 30
+          continueOnMissingPermissions: false


### PR DESCRIPTION
Why?

PRs are usually open for a few days until a maintainer can take a look. When this happens a Pull Request (PR) might already be outdated without the author being notified of this. A maintainer either has to resolve them (which takes time) or has to ping the author. This creates a feedback loop that can be reduced by this action.

This actions achieve this with minimal noise (no comment bloat) by adding a label to a PR if it has merge conflicts. This means the author has a single overview of which PRs need a rebase by using their list of created PRs. At the same time the maintainer has a simple filter for PRs that have merge conflicts.

See [eps1lon/actions-label-merge-conflict](https://github.com/eps1lon/actions-label-merge-conflict?tab=readme-ov-file#why)