### PR TITLE
feat: Rework PAT to use headers only

### DIFF
--- a/src/gitingest/clone.py
+++ b/src/gitingest/clone.py
@@ -12,7 +12,6 @@ from gitingest.utils.git_utils import (
     create_git_auth_header,
     create_git_command,
     ensure_git_installed,
-    is_github_host,
     resolve_commit,
     run_command,
 )

--- a/src/gitingest/clone.py
+++ b/src/gitingest/clone.py
@@ -40,7 +40,7 @@ async def clone_repo(config: CloneConfig, *, token: str | None = None) -> None:
     config : CloneConfig
         The configuration for cloning the repository.
     token : str | None
-        GitHub personal access token (PAT) for accessing private repositories.
+        Personal access token (PAT) for accessing private repositories.
 
     Raises
     ------
@@ -84,7 +84,7 @@ async def clone_repo(config: CloneConfig, *, token: str | None = None) -> None:
     logger.debug("Resolved commit", extra={"commit": commit})
 
     clone_cmd = ["git"]
-    if token and is_github_host(url):
+    if token:
         clone_cmd += ["-c", create_git_auth_header(token, url=url)]
 
     clone_cmd += ["clone", "--single-branch", "--no-checkout", "--depth=1"]

--- a/src/gitingest/utils/auth.py
+++ b/src/gitingest/utils/auth.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import os
 
-from gitingest.utils.git_utils import validate_github_token
-
 
 def resolve_token(token: str | None) -> str | None:
     """Resolve the token to use for the query.
@@ -13,7 +11,7 @@ def resolve_token(token: str | None) -> str | None:
     Parameters
     ----------
     token : str | None
-        GitHub personal access token (PAT) for accessing private repositories.
+        Personal access token (PAT) for accessing private repositories.
 
     Returns
     -------
@@ -21,7 +19,5 @@ def resolve_token(token: str | None) -> str | None:
         The resolved token.
 
     """
-    token = token or os.getenv("GITHUB_TOKEN")
-    if token:
-        validate_github_token(token)
+    token = token or os.getenv("GITHUB_TOKEN")  # Keep env var name for backward compatibility
     return token

--- a/src/gitingest/utils/exceptions.py
+++ b/src/gitingest/utils/exceptions.py
@@ -16,12 +16,4 @@ class InvalidNotebookError(Exception):
         super().__init__(message)
 
 
-class InvalidGitHubTokenError(ValueError):
-    """Exception raised when a GitHub Personal Access Token is malformed."""
 
-    def __init__(self) -> None:
-        msg = (
-            "Invalid GitHub token format. To generate a token, go to "
-            "https://github.com/settings/tokens/new?description=gitingest&scopes=repo."
-        )
-        super().__init__(msg)

--- a/src/gitingest/utils/git_utils.py
+++ b/src/gitingest/utils/git_utils.py
@@ -9,10 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Iterable
 from urllib.parse import urlparse
 
-import httpx
-from starlette.status import HTTP_200_OK, HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
-from gitingest.utils.compat_func import removesuffix
 
 from gitingest.utils.logging_config import get_logger
 
@@ -24,23 +21,6 @@ logger = get_logger(__name__)
 
 
 
-
-def is_github_host(url: str) -> bool:
-    """Check if a URL is from a GitHub host (github.com or GitHub Enterprise).
-
-    Parameters
-    ----------
-    url : str
-        The URL to check
-
-    Returns
-    -------
-    bool
-        True if the URL is from a GitHub host, False otherwise
-
-    """
-    hostname = urlparse(url).hostname or ""
-    return hostname.startswith("github.")
 
 
 async def run_command(*args: str) -> tuple[bytes, bytes]:
@@ -115,80 +95,27 @@ async def check_repo_exists(url: str, token: str | None = None) -> bool:
     url : str
         URL of the Git repository to check.
     token : str | None
-        GitHub personal access token (PAT) for accessing private repositories.
+        Personal access token (PAT) for accessing private repositories.
 
     Returns
     -------
     bool
         ``True`` if the repository exists, ``False`` otherwise.
 
-    Raises
-    ------
-    RuntimeError
-        If the host returns an unrecognised status code.
-
     """
-    headers = {}
-
-    if token and is_github_host(url):
-        host, owner, repo = _parse_github_url(url)
-        # Public GitHub vs. GitHub Enterprise
-        base_api = "https://api.github.com" if host == "github.com" else f"https://{host}/api/v3"
-        url = f"{base_api}/repos/{owner}/{repo}"
-        headers["Authorization"] = f"Bearer {token}"
-
-    async with httpx.AsyncClient(follow_redirects=True) as client:
-        try:
-            response = await client.head(url, headers=headers)
-        except httpx.RequestError:
-            return False
-
-    status_code = response.status_code
-
-    if status_code == HTTP_200_OK:
+    try:
+        # Use git ls-remote to check if repository exists
+        cmd = ["git"]
+        if token:
+            cmd += ["-c", create_git_auth_header(token, url=url)]
+        cmd += ["ls-remote", "--heads", url]
+        
+        await run_command(*cmd)
         return True
-    if status_code in {HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND}:
+    except Exception:
         return False
-    msg = f"Unexpected HTTP status {status_code} for {url}"
-    raise RuntimeError(msg)
 
 
-def _parse_github_url(url: str) -> tuple[str, str, str]:
-    """Parse a GitHub URL and return (hostname, owner, repo).
-
-    Parameters
-    ----------
-    url : str
-        The URL of the GitHub repository to parse.
-
-    Returns
-    -------
-    tuple[str, str, str]
-        A tuple containing the hostname, owner, and repository name.
-
-    Raises
-    ------
-    ValueError
-        If the URL is not a valid GitHub repository URL.
-
-    """
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"}:
-        msg = f"URL must start with http:// or https://: {url!r}"
-        raise ValueError(msg)
-
-    if not parsed.hostname or not parsed.hostname.startswith("github."):
-        msg = f"Un-recognised GitHub hostname: {parsed.hostname!r}"
-        raise ValueError(msg)
-
-    parts = removesuffix(parsed.path, ".git").strip("/").split("/")
-    expected_path_length = 2
-    if len(parts) != expected_path_length:
-        msg = f"Path must look like /<owner>/<repo>: {parsed.path!r}"
-        raise ValueError(msg)
-
-    owner, repo = parts
-    return parsed.hostname, owner, repo
 
 
 async def fetch_remote_branches_or_tags(url: str, *, ref_type: str, token: str | None = None) -> list[str]:
@@ -201,7 +128,7 @@ async def fetch_remote_branches_or_tags(url: str, *, ref_type: str, token: str |
     ref_type: str
         The type of reference to fetch. Can be "branches" or "tags".
     token : str | None
-        GitHub personal access token (PAT) for accessing private repositories.
+        Personal access token (PAT) for accessing private repositories.
 
     Returns
     -------
@@ -221,7 +148,7 @@ async def fetch_remote_branches_or_tags(url: str, *, ref_type: str, token: str |
     cmd = ["git"]
 
     # Add authentication if needed
-    if token and is_github_host(url):
+    if token:
         cmd += ["-c", create_git_auth_header(token, url=url)]
 
     cmd += ["ls-remote"]
@@ -314,7 +241,7 @@ async def checkout_partial_clone(config: CloneConfig, token: str | None) -> None
     config : CloneConfig
         The configuration for cloning the repository, including subpath and blob flag.
     token : str | None
-        GitHub personal access token (PAT) for accessing private repositories.
+        Personal access token (PAT) for accessing private repositories.
 
     """
     subpath = config.subpath.lstrip("/")
@@ -333,7 +260,7 @@ async def resolve_commit(config: CloneConfig, token: str | None) -> str:
     config : CloneConfig
         The configuration for cloning the repository.
     token : str | None
-        GitHub personal access token (PAT) for accessing private repositories.
+        Personal access token (PAT) for accessing private repositories.
 
     Returns
     -------
@@ -365,7 +292,7 @@ async def _resolve_ref_to_sha(url: str, pattern: str, token: str | None = None) 
     pattern : str
         The pattern to use to resolve the commit SHA.
     token : str | None
-        GitHub personal access token (PAT) for accessing private repositories.
+        Personal access token (PAT) for accessing private repositories.
 
     Returns
     -------
@@ -380,7 +307,7 @@ async def _resolve_ref_to_sha(url: str, pattern: str, token: str | None = None) 
     """
     # Build: git [-c http.<host>/.extraheader=Auth...] ls-remote <url> <pattern>
     cmd: list[str] = ["git"]
-    if token and is_github_host(url):
+    if token:
         cmd += ["-c", create_git_auth_header(token, url=url)]
 
     cmd += ["ls-remote", url, pattern]

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 from gitingest.clone import clone_repo
 from gitingest.ingestion import ingest_query
 from gitingest.query_parser import parse_remote_repo
-from gitingest.utils.git_utils import resolve_commit, validate_github_token
+from gitingest.utils.git_utils import resolve_commit
 from gitingest.utils.logging_config import get_logger
 from gitingest.utils.pattern_utils import process_patterns
 from server.models import IngestErrorResponse, IngestResponse, IngestSuccessResponse, PatternType, S3Metadata
@@ -262,9 +262,6 @@ async def process_query(
         If the commit hash is not found (should never happen).
 
     """
-    if token:
-        validate_github_token(token)
-
     try:
         query = await parse_remote_repo(input_text, token=token)
     except Exception as exc:


### PR DESCRIPTION
Generalize PAT handling to support all Git services by removing GitHub-specific logic and passing tokens directly in headers.

---
[Slack Thread](https://coderampgroupe.slack.com/archives/C09AF2TKP32/p1754746550967979?thread_ts=1754746550.967979&cid=C09AF2TKP32)

<a href="https://cursor.com/background-agent?bcId=bc-a5bf5f90-b9bf-4657-87ce-3b1b68d1fedc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5bf5f90-b9bf-4657-87ce-3b1b68d1fedc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

