### PR TITLE
Rework check_repo_exists to use git ls-remote

### DIFF
--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -11,9 +11,7 @@ import sys
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
-import httpx
 import pytest
-from starlette.status import HTTP_200_OK, HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
 from gitingest.clone import clone_repo
 from gitingest.schemas import CloneConfig


### PR DESCRIPTION
Refactor Git operations to use GitPython and `git ls-remote` for improved robustness and simplified authentication.

---
[Slack Thread](https://coderampgroupe.slack.com/archives/C09AF2TKP32/p1754746430133059?thread_ts=1754746430.133059&cid=C09AF2TKP32)

<a href="https://cursor.com/background-agent?bcId=bc-a3a8d023-573b-43cb-998f-68d2b427aa8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3a8d023-573b-43cb-998f-68d2b427aa8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

