### PR TITLE
Add project context from coderamp-labs/gitingest

### DIFF
--- a/.context/business.md
+++ b/.context/business.md
@@ -1,0 +1,13 @@
+# Business Logic
+
+## Project Description
+Replace 'hub' with 'ingest' in any GitHub URL to get a prompt-friendly extract of a codebase 
+
+## Core Features
+_List the main features and functionality_
+
+## Business Rules
+_Document important business rules and constraints_
+
+## User Stories
+_Add key user stories and use cases_

--- a/.context/guidelines.md
+++ b/.context/guidelines.md
@@ -1,0 +1,5 @@
+# Development Guidelines
+
+## Contributing Guidelines
+# See CONTRIBUTING.md in the repository
+

--- a/.context/people.md
+++ b/.context/people.md
@@ -1,0 +1,25 @@
+# People
+
+## Contributors
+### Romain Courtois
+- **GitHub**: [@cyclotruc](https://github.com/cyclotruc)
+- **Bio**: I make open-source devtools for the AI era
+
+- **Website**: [https://coderamp.io](https://coderamp.io)
+- **Email**: romain@coderamp.io
+- **Twitter**: [@romdot2](https://twitter.com/romdot2)
+
+### Mickael
+- **GitHub**: [@MickaelCa](https://github.com/MickaelCa)
+- **Location**: Rennes
+
+### Nicolas Iragne
+- **GitHub**: [@NicolasIRAGNE](https://github.com/NicolasIRAGNE)
+- **Bio**: I wish I were proficient at CMake
+- **Location**: France
+
+## Team Roles
+_Define roles and responsibilities_
+
+## Contact Information
+_Add relevant contact information_

--- a/.context/stack.md
+++ b/.context/stack.md
@@ -1,0 +1,19 @@
+# Technology Stack
+
+## Languages
+- **Dockerfile**
+- **HTML**
+- **JavaScript**
+- **Jinja**
+- **Python**
+- **Shell**
+
+## Frameworks & Libraries
+_Add frameworks and libraries used in this project_
+
+## Tools & Services
+_Add development tools, CI/CD, and services used_
+
+## Architecture
+_Describe the high-level architecture of the project_
+C bien


### PR DESCRIPTION
This PR adds project context files from the Context Marketplace.

**Context:** coderamp-labs/gitingest
**Description:** Replace 'hub' with 'ingest' in any GitHub URL to get a prompt-friendly extract of a codebase 

## Files Added:
- `.context/stack.md`
- `.context/business.md`
- `.context/people.md`
- `.context/guidelines.md`

## What is this?
These files contain project context information including:
- Technology stack and architecture
- Business logic and requirements  
- Team information and contributors
- Development guidelines and standards

The `.context/` directory helps new contributors understand the project quickly and provides context for AI tools and code assistants.

---
*Created by @NicolasIRAGNE via [Context Marketplace]()*
