### PR TITLE
fix: Python Package RuntimeError: templates and static do not exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ server = [
     "uvicorn>=0.11.7",  # Minimum safe release (https://osv.dev/vulnerability/PYSEC-2020-150)
 ]
 
+static = []
+
 [project.scripts]
 gitingest = "gitingest.__main__:main"
 
@@ -67,6 +69,10 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = {find = {where = ["src"]}}
 include-package-data = true
+
+[tool.setuptools.package-data]
+server = ["templates/**/*"]
+static = ["**/*"]
 
 # Linting configuration
 [tool.pylint.format]


### PR DESCRIPTION
# Fix Python Package RuntimeError: Templates and Static Do Not Exist

## Overview

This PR fixes bug [#529].

## Changes Made

`pyproject.toml`

- Configured setuptools' package data
- Added `static` as an empty optional dependency

## Steps to Test Changes

```
conda create --name gitingest python=3.13 -y
```

```
conda activate gitingest
```

```
pip install .[server,static]
```

```
python -m server
```