### PR TITLE
feat: Add folder upload functionality

### DIFF
--- a/jules-scratch/verification/dummy_folder/file1.txt
+++ b/jules-scratch/verification/dummy_folder/file1.txt
@@ -1,0 +1,1 @@
+This is file1.

--- a/jules-scratch/verification/dummy_folder/subdir/file2.txt
+++ b/jules-scratch/verification/dummy_folder/subdir/file2.txt
@@ -1,0 +1,1 @@
+This is file2.

--- a/jules-scratch/verification/verify_upload.py
+++ b/jules-scratch/verification/verify_upload.py
@@ -1,0 +1,26 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    page = browser.new_page()
+    page.goto("http://localhost:8000")
+
+    # Create dummy files to upload
+    import os
+    os.makedirs("jules-scratch/verification/dummy_folder/subdir", exist_ok=True)
+    file1_path = "jules-scratch/verification/dummy_folder/file1.txt"
+    file2_path = "jules-scratch/verification/dummy_folder/subdir/file2.txt"
+    with open(file1_path, "w") as f:
+        f.write("This is file1.")
+    with open(file2_path, "w") as f:
+        f.write("This is file2.")
+
+    # Set the input files on the hidden input element
+    page.set_input_files("input[type=file]", [file1_path, file2_path])
+
+    page.screenshot(path="jules-scratch/verification/upload_verification.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/gitingest/ingestion.py
+++ b/src/gitingest/ingestion.py
@@ -13,6 +13,7 @@ from gitingest.utils.logging_config import get_logger
 
 if TYPE_CHECKING:
     from gitingest.schemas import IngestionQuery
+    from server.models import UploadedFile
 
 # Initialize logger for this module
 logger = get_logger(__name__)
@@ -118,6 +119,79 @@ def ingest_query(query: IngestionQuery) -> tuple[str, str, str]:
     )
 
     return format_node(root_node, query=query)
+
+
+def ingest_uploaded_files(
+    files: list[UploadedFile],
+    max_file_size: int,
+    ignore_patterns: list[str] | None = None,
+    include_patterns: list[str] | None = None,
+) -> tuple[str, str, str]:
+    """Run the ingestion process for a list of uploaded files."""
+    root_node = FileSystemNode(
+        name="root",
+        type=FileSystemNodeType.DIRECTORY,
+        path_str="",
+        path=Path(""),
+    )
+
+    stats = FileSystemStats()
+
+    for file in files:
+        if limit_exceeded(stats, depth=0):
+            break
+
+        path = Path(file.webkitRelativePath)
+
+        if ignore_patterns and _should_exclude(path, Path(""), ignore_patterns):
+            continue
+
+        if include_patterns and not _should_include(path, Path(""), include_patterns):
+            continue
+
+        file_size = len(file.content)
+        if file_size > max_file_size:
+            continue
+
+        if stats.total_files + 1 > MAX_FILES:
+            break
+
+        if stats.total_size + file_size > MAX_TOTAL_SIZE_BYTES:
+            break
+
+        stats.total_files += 1
+        stats.total_size += file_size
+
+        # Create nested structure
+        parts = path.parts
+        current_node = root_node
+        for i, part in enumerate(parts):
+            is_file = (i == len(parts) - 1)
+            child_node = next((c for c in current_node.children if c.name == part), None)
+            if not child_node:
+                if is_file:
+                    child_node = FileSystemNode(
+                        name=part,
+                        type=FileSystemNodeType.FILE,
+                        size=file_size,
+                        file_count=1,
+                        path_str=str(path),
+                        path=path,
+                        depth=i + 1,
+                        content=file.content
+                    )
+                else:
+                    child_node = FileSystemNode(
+                        name=part,
+                        type=FileSystemNodeType.DIRECTORY,
+                        path_str=str(Path(*parts[:i+1])),
+                        path=Path(*parts[:i+1]),
+                        depth=i + 1,
+                    )
+                current_node.children.append(child_node)
+            current_node = child_node
+
+    return format_node(root_node)
 
 
 def _process_node(node: FileSystemNode, query: IngestionQuery, stats: FileSystemStats) -> None:

--- a/src/server/models.py
+++ b/src/server/models.py
@@ -196,3 +196,17 @@ class QueryForm(BaseModel):
             pattern=pattern,
             token=token,
         )
+
+
+class UploadedFile(BaseModel):
+    """Represents a single file uploaded by the user."""
+    name: str
+    content: str
+    webkitRelativePath: str
+
+class UploadRequest(BaseModel):
+    """Request model for the /api/upload endpoint."""
+    files: list[UploadedFile]
+    max_file_size: int = Field(..., ge=1, le=MAX_FILE_SIZE_KB, description="File size in KB")
+    pattern_type: PatternType = Field(default=PatternType.EXCLUDE, description="Pattern type for file filtering")
+    pattern: str = Field(default="", description="Glob/regex pattern for file filtering")

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from gitingest.clone import clone_repo
-from gitingest.ingestion import ingest_query
+from gitingest.ingestion import ingest_query, ingest_uploaded_files
 from gitingest.query_parser import parse_remote_repo
 from gitingest.utils.git_utils import resolve_commit, validate_github_token
 from gitingest.utils.logging_config import get_logger
@@ -30,6 +30,7 @@ logger = get_logger(__name__)
 if TYPE_CHECKING:
     from gitingest.schemas.cloning import CloneConfig
     from gitingest.schemas.ingestion import IngestionQuery
+    from server.models import UploadedFile
 
 
 def _cleanup_repository(clone_config: CloneConfig) -> None:
@@ -340,6 +341,47 @@ async def process_query(
         pattern_type=pattern_type,
         pattern=pattern,
     )
+
+
+async def process_uploaded_folder(
+    files: list[UploadedFile],
+    max_file_size: int,
+    pattern_type: PatternType,
+    pattern: str,
+) -> IngestResponse:
+    """Process a folder of uploaded files and generate a summary."""
+    try:
+        ignore_patterns, include_patterns = process_patterns(
+            exclude_patterns=pattern if pattern_type == PatternType.EXCLUDE else None,
+            include_patterns=pattern if pattern_type == PatternType.INCLUDE else None,
+        )
+
+        summary, tree, content = ingest_uploaded_files(
+            files=files,
+            max_file_size=max_file_size * 1024,  # Convert KB to bytes
+            ignore_patterns=ignore_patterns,
+            include_patterns=include_patterns,
+        )
+
+        if len(content) > MAX_DISPLAY_SIZE:
+            content = (
+                f"(Files content cropped to {int(MAX_DISPLAY_SIZE / 1_000)}k characters, "
+                "download full ingest to see more)\n" + content[:MAX_DISPLAY_SIZE]
+            )
+
+        return IngestSuccessResponse(
+            repo_url="Uploaded Folder",
+            short_repo_url="Uploaded Folder",
+            summary=summary,
+            digest_url="",  # No download URL for uploaded folders yet
+            tree=tree,
+            content=content,
+            default_max_file_size=max_file_size,
+            pattern_type=pattern_type.value,
+            pattern=pattern,
+        )
+    except Exception as exc:
+        return IngestErrorResponse(error=f"{exc!s}")
 
 
 def _print_query(url: str, max_file_size: int, pattern_type: str, pattern: str) -> None:

--- a/src/server/routers/ingest.py
+++ b/src/server/routers/ingest.py
@@ -8,9 +8,10 @@ from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from prometheus_client import Counter
 
 from gitingest.config import TMP_BASE_PATH
-from server.models import IngestRequest
+from server.models import IngestRequest, UploadRequest, PatternType, IngestErrorResponse
 from server.routers_utils import COMMON_INGEST_RESPONSES, _perform_ingestion
 from server.s3_utils import is_s3_enabled
+from server.query_processor import process_uploaded_folder
 from server.server_config import DEFAULT_FILE_SIZE_KB
 from server.server_utils import limiter
 
@@ -50,6 +51,24 @@ async def api_ingest(
     # limit URL to 255 characters
     ingest_counter.labels(status=response.status_code, url=ingest_request.input_text[:255]).inc()
     return response
+
+
+@router.post("/api/upload", responses=COMMON_INGEST_RESPONSES)
+@limiter.limit("10/minute")
+async def api_upload(
+    request: Request,
+    upload_request: UploadRequest,
+) -> JSONResponse:
+    """Ingest a folder of files and return processed content."""
+    result = await process_uploaded_folder(
+        files=upload_request.files,
+        max_file_size=upload_request.max_file_size,
+        pattern_type=PatternType(upload_request.pattern_type),
+        pattern=upload_request.pattern,
+    )
+    if isinstance(result, IngestErrorResponse):
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=result.model_dump())
+    return JSONResponse(status_code=status.HTTP_200_OK, content=result.model_dump())
 
 
 @router.get("/api/{user}/{repository}", responses=COMMON_INGEST_RESPONSES)

--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -26,6 +26,15 @@
                         Ingest
                     </button>
                 </div>
+                <!-- Upload Folder button -->
+                <div class="relative w-auto flex-shrink-0 h-full group">
+                    <div class="w-full h-full rounded bg-gray-800 translate-y-1 translate-x-1 absolute inset-0 z-10"></div>
+                    <button type="button"
+                            id="uploadFolderBtn"
+                            class="py-3.5 rounded px-6 group-hover:-translate-y-px group-hover:-translate-x-px ease-out duration-300 z-20 relative w-full border-[3px] border-gray-900 font-medium bg-[#ffc480] tracking-wide text-lg flex-shrink-0 text-gray-900">
+                        Upload Folder
+                    </button>
+                </div>
             </div>
             <!-- Hidden fields -->
             <input type="hidden" name="pattern_type" value="exclude">
@@ -177,3 +186,4 @@
 </div>
 <script defer src="/static/js/git.js"></script>
 <script defer src="/static/js/git_form.js"></script>
+<script defer src="/static/js/upload_form.js"></script>

--- a/src/static/js/upload_form.js
+++ b/src/static/js/upload_form.js
@@ -1,0 +1,73 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const uploadFolderBtn = document.getElementById('uploadFolderBtn');
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.webkitdirectory = true;
+    fileInput.style.display = 'none';
+    document.body.appendChild(fileInput);
+
+    if (uploadFolderBtn) {
+        uploadFolderBtn.addEventListener('click', () => {
+            fileInput.click();
+        });
+    }
+
+    fileInput.addEventListener('change', async (event) => {
+        try {
+            const files = event.target.files;
+            const fileData = [];
+            for (const file of files) {
+                const content = await file.text();
+                fileData.push({
+                    name: file.name,
+                    content: content,
+                    webkitRelativePath: file.webkitRelativePath
+                });
+            }
+
+            const patternType = document.getElementById('pattern_type').value;
+            const pattern = document.getElementById('pattern').value;
+            const max_file_size = document.getElementById('file_size').value;
+
+            const response = await fetch('/api/upload', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    files: fileData,
+                    pattern_type: patternType,
+                    pattern: pattern,
+                    max_file_size: max_file_size,
+                }),
+            });
+
+            const result = await response.json();
+            handleUploadResponse(result);
+
+        } catch (error) {
+            console.error('Error processing directory:', error);
+        }
+    });
+
+    function handleUploadResponse(result) {
+        if (result.error) {
+            const errorMessage = document.getElementById('error-message');
+            errorMessage.textContent = result.error;
+            errorMessage.classList.remove('hidden');
+            return;
+        }
+
+        const resultContainer = document.getElementById('resultContainer');
+        const summaryElement = resultContainer.querySelector('#summary');
+        const treeElement = resultContainer.querySelector('#tree');
+        const contentElement = resultContainer.querySelector('#content');
+        const shortRepoUrlElement = resultContainer.querySelector('#short_repo_url');
+
+        summaryElement.textContent = result.summary;
+        treeElement.textContent = result.tree;
+        contentElement.textContent = result.content;
+        shortRepoUrlElement.textContent = result.short_repo_url;
+        resultContainer.classList.remove('hidden');
+    }
+});


### PR DESCRIPTION
This commit introduces a new feature that allows users to upload a folder of files to be ingested and processed.

The following changes have been made:

- Added an "Upload Folder" button to the UI.
- Implemented a new JavaScript module to handle folder selection and file reading.
- Created a new API endpoint `/api/upload` to receive the uploaded file data.
- Implemented the business logic to process the uploaded folder and generate a digest.
- Added new Pydantic models for the upload request.