### PR TITLE
fix(ingest): validate single file existence against git reference

### DIFF
--- a/src/gitingest/ingestion.py
+++ b/src/gitingest/ingestion.py
@@ -67,6 +67,18 @@ def ingest_query(query: IngestionQuery) -> tuple[str, str, str]:
             logger.error("Expected file but found non-file", extra={"path": str(path)})
             msg = f"Path {path} is not a file"
             raise ValueError(msg)
+        
+        if query.url:
+            from gitingest.utils.git_utils import create_git_repo
+            repo = create_git_repo(str(query.local_path), query.url)
+            
+            try:
+                # Verify the path exists in the specific Git reference
+                rev_path = f"{query.commit or query.branch or 'HEAD'}:{query.subpath.lstrip('/')}"
+                repo.git.rev_parse("--verify", rev_path)
+            except Exception as exc:
+                msg = f"File '{query.subpath}' not found in the requested Git reference."
+                raise ValueError(msg) from exc
 
         relative_path = path.relative_to(query.local_path)
 


### PR DESCRIPTION
### 🚀 Description
This PR addresses a critical logic gap in single-file (blob) ingestion. Previously, the system checked for file existence only on the local filesystem of the shallow clone, potentially ignoring the specific branch or commit requested. This implementation enforces strict Git-based validation as noted in the codebase TODO.

### 🛠️ Changes Made
- **Validation Logic**: Updated `ingest_query` in `ingestion.py` to use `git rev-parse --verify` to confirm the requested subpath exists within the provided Git reference (commit, tag, or branch).
- **Error Handling**: Implemented a specific `ValueError` that informs the user if a file is not found in the requested Git state, preventing the system from falling back to incorrect local file versions.

### ✅ Testing Performed
- **Manual Verification**: Confirmed that requesting a valid file on `main` works as expected.
- **Negative Testing**: Verified that requesting a file on a branch where it does not exist now returns a `ValueError` instead of the version from the default branch.
- **CI Readiness**: Ensured all pre-commit hooks (`ruff`, `pydoclint`, `isort`) pass locally.

### 🔗 Related Issues
Closes #557