### PR TITLE
feat: add --append option to CLI to prevent overwriting output

### DIFF
--- a/src/gitingest/__main__.py
+++ b/src/gitingest/__main__.py
@@ -29,6 +29,7 @@ class _CLIArgs(TypedDict):
     include_submodules: bool
     token: str | None
     output: str | None
+    append: bool
 
 
 @click.command()
@@ -76,6 +77,13 @@ class _CLIArgs(TypedDict):
     default=None,
     help="Output file path (default: digest.txt in current directory). Use '-' for stdout.",
 )
+@click.option(
+    "--append",
+    "-a",
+    is_flag=True,
+    default=False,
+    help="Append to the output file instead of overwriting it.",
+)
 def main(**cli_kwargs: Unpack[_CLIArgs]) -> None:
     """Run the CLI entry point to analyze a repo / directory and dump its contents.
 
@@ -110,6 +118,9 @@ def main(**cli_kwargs: Unpack[_CLIArgs]) -> None:
     Include submodules:
         $ gitingest https://github.com/user/repo --include-submodules
 
+    Append to existing file:
+        $ gitingest -o digest.txt --append
+
     """
     asyncio.run(_async_main(**cli_kwargs))
 
@@ -125,6 +136,7 @@ async def _async_main(
     include_submodules: bool = False,
     token: str | None = None,
     output: str | None = None,
+    append: bool = False,
 ) -> None:
     """Analyze a directory or repository and create a text dump of its contents.
 
@@ -154,6 +166,8 @@ async def _async_main(
     output : str | None
         The path where the output file will be written (default: ``digest.txt`` in current directory).
         Use ``"-"`` to write to ``stdout``.
+    append : bool
+        If ``True``, append to the output file instead of overwriting it (default: ``False``).
 
     Raises
     ------
@@ -171,7 +185,8 @@ async def _async_main(
         if output_target == "-":
             click.echo("Analyzing source, preparing output for stdout...", err=True)
         else:
-            click.echo(f"Analyzing source, output will be written to '{output_target}'...", err=True)
+            action = "appended" if append else "written"
+            click.echo(f"Analyzing source, output will be {action} to '{output_target}'...", err=True)
 
         summary, _, _ = await ingest_async(
             source,
@@ -183,6 +198,7 @@ async def _async_main(
             include_submodules=include_submodules,
             token=token,
             output=output_target,
+            append=append,
         )
     except Exception as exc:
         # Convert any exception into Click.Abort so that exit status is non-zero
@@ -195,7 +211,8 @@ async def _async_main(
         click.echo("--- End Summary ---", err=True)
         click.echo("Analysis complete! Output sent to stdout.", err=True)
     else:  # file
-        click.echo(f"Analysis complete! Output written to: {output_target}")
+        action = "appended" if append else "written"
+        click.echo(f"Analysis complete! Output {action} to: {output_target}")
         click.echo("\nSummary:")
         click.echo(summary)
 

--- a/src/gitingest/entrypoint.py
+++ b/src/gitingest/entrypoint.py
@@ -44,6 +44,7 @@ async def ingest_async(
     include_submodules: bool = False,
     token: str | None = None,
     output: str | None = None,
+    append: bool = False,
 ) -> tuple[str, str, str]:
     """Ingest a source and process its contents.
 
@@ -76,6 +77,8 @@ async def ingest_async(
         File path where the summary and content should be written.
         If ``"-"`` (dash), the results are written to ``stdout``.
         If ``None``, the results are not written to a file.
+    append : bool
+        If ``True``, append to the output file instead of overwriting it (default: ``False``).
 
     Returns
     -------
@@ -141,8 +144,8 @@ async def ingest_async(
         summary, tree, content = ingest_query(query)
 
         if output:
-            logger.debug("Writing output to file", extra={"output_path": output})
-        await _write_output(tree, content=content, target=output)
+            logger.debug("Writing output to file", extra={"output_path": output, "append": append})
+        await _write_output(tree, content=content, target=output, append=append)
 
         logger.info("Ingestion completed successfully")
         return summary, tree, content
@@ -160,6 +163,7 @@ def ingest(
     include_submodules: bool = False,
     token: str | None = None,
     output: str | None = None,
+    append: bool = False,
 ) -> tuple[str, str, str]:
     """Provide a synchronous wrapper around ``ingest_async``.
 
@@ -192,6 +196,8 @@ def ingest(
         File path where the summary and content should be written.
         If ``"-"`` (dash), the results are written to ``stdout``.
         If ``None``, the results are not written to a file.
+    append : bool
+        If ``True``, append to the output file instead of overwriting it (default: ``False``).
 
     Returns
     -------
@@ -218,6 +224,7 @@ def ingest(
             include_submodules=include_submodules,
             token=token,
             output=output,
+            append=append,
         ),
     )
 
@@ -330,7 +337,13 @@ def _handle_remove_readonly(
     func(path)
 
 
-async def _write_output(tree: str, content: str, target: str | None) -> None:
+def _save_file(target: str, data: str, mode: str) -> None:
+    """Write data to the target file using the specified mode."""
+    with open(target, mode, encoding="utf-8") as f:
+        f.write(data)
+
+
+async def _write_output(tree: str, content: str, target: str | None, append: bool = False) -> None:
     """Write combined output to ``target`` (``"-"`` ⇒ stdout).
 
     Parameters
@@ -341,6 +354,8 @@ async def _write_output(tree: str, content: str, target: str | None) -> None:
         The content of the files in the repository or directory.
     target : str | None
         The path to the output file. If ``None``, the results are not written to a file.
+    append : bool
+        If ``True``, append to the output file instead of overwriting it.
 
     """
     data = f"{tree}\n{content}"
@@ -349,4 +364,5 @@ async def _write_output(tree: str, content: str, target: str | None) -> None:
         await loop.run_in_executor(None, sys.stdout.write, data)
         await loop.run_in_executor(None, sys.stdout.flush)
     elif target is not None:
-        await loop.run_in_executor(None, Path(target).write_text, data, "utf-8")
+        mode = "a" if append else "w"
+        await loop.run_in_executor(None, _save_file, target, data, mode)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,25 @@ def test_cli_with_stdout_output() -> None:
         if output_file.exists():
             output_file.unlink()
 
+def test_cli_append_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that using --append appends to the file instead of overwriting."""
+    monkeypatch.chdir(tmp_path)
+    output_file = tmp_path / "digest.txt"
+
+    # First run (create)
+    result1 = _invoke_isolated_cli_runner(["./", "-o", "digest.txt"])
+    assert result1.exit_code == 0
+    assert output_file.exists()
+    content1 = output_file.read_text("utf-8")
+
+    # Second run (append)
+    result2 = _invoke_isolated_cli_runner(["./", "-o", "digest.txt", "--append"])
+    assert result2.exit_code == 0
+    content2 = output_file.read_text("utf-8")
+
+    assert len(content2) > len(content1)
+    # The file should now contain the directory structure twice
+    assert content2.count("Directory structure:") == 2
 
 def _invoke_isolated_cli_runner(args: list[str]) -> Result:
     """Return a ``CliRunner`` that keeps ``stderr`` separate on Click 8.0-8.1."""


### PR DESCRIPTION
## Description
This PR adds a new `--append` / `-a` flag to the CLI and the `ingest` function. 

### Problem
Currently, running `gitingest` against a repository overwrites the output file (default `digest.txt`) if it already exists. Users who want to combine multiple analyses into a single file cannot do so easily.

### Solution
- Added `--append` flag to the CLI arguments.
- Updated `entrypoint.py` to accept an `append` boolean.
- Updated file writing logic to use mode `'a'` when append is True, and `'w'` otherwise.
- Added a CLI test case in `tests/test_cli.py` to verify the content is actually appended.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Added `test_cli_append_output` in `tests/test_cli.py`.
- [x] Ran full test suite via `pytest`.

## Related issue
- https://github.com/coderamp-labs/gitingest/issues/565