### PR TITLE
fix: include max_file_size in S3 cache key to prevent stale digests

### DIFF
--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -93,6 +93,7 @@ async def _check_s3_cache(
             subpath=query.subpath,
             include_patterns=query.include_patterns,
             ignore_patterns=query.ignore_patterns,
+            max_file_size=query.max_file_size,
         )
 
         # Check if file exists on S3
@@ -172,6 +173,7 @@ def _store_digest_content(
             subpath=query.subpath,
             include_patterns=query.include_patterns,
             ignore_patterns=query.ignore_patterns,
+            max_file_size=query.max_file_size,
         )
         s3_url = upload_to_s3(content=digest_content, s3_file_path=s3_file_path, ingest_id=query.id)
 

--- a/src/server/s3_utils.py
+++ b/src/server/s3_utils.py
@@ -65,6 +65,7 @@ def generate_s3_file_path(
     subpath: str,
     include_patterns: set[str] | None,
     ignore_patterns: set[str],
+    max_file_size: int,
 ) -> str:
     """Generate S3 file path with proper naming convention.
 
@@ -92,6 +93,8 @@ def generate_s3_file_path(
         Set of patterns specifying which files to include.
     ignore_patterns : set[str]
         Set of patterns specifying which files to exclude.
+    max_file_size : int
+        Maximum file size in bytes to include in the ingestion.
 
     Returns
     -------
@@ -110,9 +113,10 @@ def generate_s3_file_path(
         logger.error(msg)
         raise ValueError(msg)
 
-    # Create hash of exclude/include patterns for uniqueness
+    # Create hash of exclude/include patterns and size for uniqueness
     patterns_str = f"include:{sorted(include_patterns) if include_patterns else []}"
     patterns_str += f"exclude:{sorted(ignore_patterns)}"
+    patterns_str += f"size:{max_file_size}"
     patterns_hash = hashlib.sha256(patterns_str.encode()).hexdigest()[:16]
     subpath_hash = hashlib.sha256(subpath.encode()).hexdigest()[:16]
 


### PR DESCRIPTION
This PR fixes a caching bug where S3 cache keys did not account for `max_file_size` (see #568).

Previously, if a repository was requested with the default 50KB limit, and then requested again with a 100MB limit, the server would return the cached 50KB version because the cache key only relied on include/exclude patterns and the commit hash.
- Updated `generate_s3_file_path` in `src/server/s3_utils.py` to accept `max_file_size` and append it to the hashing string.
- Passed `query.max_file_size` into both calls to `generate_s3_file_path` inside `src/server/query_processor.py`.


While looking into this, I realized this strict hashing approach might cause unnecessary cache misses. For example, if a user requests a 500KB limit, and then a 2MB limit on a repo where the largest file is only 100KB, the current fix will treat them as different keys and trigger a re-clone. 

Ideally, the cache would stay the same in this instance. In the future, it might be worth adding `largest_file_encountered` to the `S3Metadata` JSON and updating the lookup logic to allow compatible cache hits. 

For now, adding the size to the hash key is a fast and reliable way to prevent the UI from serving incorrectly limited files.