### PR TITLE
docs: add opt-in understand-quickly publish workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ See more options and usage details with:
 gitingest --help
 ```
 
+To publish your digest to the [understand-quickly](https://github.com/looptech-ai/understand-quickly) registry (opt-in, machine-readable index of code-context artifacts for AI agents), see [`docs/publishing.md`](docs/publishing.md).
+
 ## 🐍 Python package usage
 
 ```python

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,51 @@
+# Publishing your digest to the understand-quickly registry
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public, machine-readable registry of code-knowledge and code-context artifacts. It indexes Gitingest digests through its [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format so AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its packed-context digest.
+
+Publishing is opt-in. The body stays in your repo and is fetched from `raw.githubusercontent.com`; the registry only stores a small JSON pointer.
+
+## One-time setup
+
+1. Register your repo with the registry (zero config — `npx @understand-quickly/cli add`, the [wizard](https://looptech-ai.github.io/understand-quickly/add.html), or a manual PR per the [registry CONTRIBUTING.md](https://github.com/looptech-ai/understand-quickly/blob/main/CONTRIBUTING.md)).
+2. Create a fine-grained GitHub PAT scoped to `looptech-ai/understand-quickly` only with `Repository dispatches: write`. Add it to your repo as the `UNDERSTAND_QUICKLY_TOKEN` secret.
+
+## Workflow
+
+Drop the following into `.github/workflows/understand-quickly-publish.yml`. It runs gitingest on every push, writes a small `bundle@1` sidecar next to `digest.txt`, then hands off to the [`looptech-ai/uq-publish-action`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action.
+
+```yaml
+name: understand-quickly publish
+on:
+  push:
+    branches: [main]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions: { contents: read }
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install gitingest && gitingest . -o digest.txt
+      - name: Build bundle@1 sidecar
+        run: |
+          python -c "
+          import json, os
+          b = os.path.getsize('digest.txt')
+          json.dump({
+            'format': 'bundle@1',
+            'manifest': {'tool': 'gitingest', 'tool_version': 'latest',
+              'generated_at': '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
+              'file_count': 0, 'byte_count': b, 'token_estimate': b // 4,
+              'format': 'plaintext'},
+            'content_url': f'https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/digest.txt'
+          }, open('digest.bundle.json', 'w'), indent=2)"
+      - uses: looptech-ai/uq-publish-action@v0.1.0
+        with:
+          graph-path: digest.bundle.json
+          format: bundle@1
+          token: ${{ secrets.UNDERSTAND_QUICKLY_TOKEN }}
+```
+
+## Notes
+
+- Submission is opt-in and gated entirely on the secret being set; without `UNDERSTAND_QUICKLY_TOKEN` the Action only stamps metadata locally and exits cleanly.
+- See the [producer protocol](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md) for the full contract and [`DATA-LICENSE.md`](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) for the data-grant semantics.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -11,7 +11,7 @@ Publishing is opt-in. The body stays in your repo and is fetched from `raw.githu
 
 ## Workflow
 
-Drop the following into `.github/workflows/understand-quickly-publish.yml`. It runs gitingest on every push, writes a small `bundle@1` sidecar next to `digest.txt`, then hands off to the [`looptech-ai/uq-publish-action`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action.
+Drop the following into `.github/workflows/understand-quickly-publish.yml`. It runs gitingest, commits the digest to a dedicated `understand-quickly` branch (so the `content_url` is actually reachable), writes a small `bundle@1` sidecar pinned to that commit SHA, then hands off to the [`looptech-ai/uq-publish-action`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action. Pin actions to a commit SHA in your own repo (omitted here for readability):
 
 ```yaml
 name: understand-quickly publish
@@ -21,23 +21,40 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions: { contents: read }
+    permissions: { contents: write }   # needs write to publish digest
     steps:
       - uses: actions/checkout@v4
-      - run: pip install gitingest && gitingest . -o digest.txt
-      - name: Build bundle@1 sidecar
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.x' }
+      - run: python -m pip install gitingest
+      - run: gitingest . -o digest.txt
+      - name: Commit digest to understand-quickly branch
         run: |
-          python -c "
-          import json, os
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout --orphan understand-quickly
+          git rm -rf --cached . >/dev/null 2>&1 || true
+          git add -f digest.txt
+          git commit -m "chore(uq): publish $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          git push --force origin understand-quickly
+          echo "UQ_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+      - name: Build bundle@1 sidecar
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ env.UQ_SHA }}
+        run: |
+          python - <<'PY'
+          import datetime, json, os
           b = os.path.getsize('digest.txt')
+          repo, sha = os.environ['REPO'], os.environ['SHA']
           json.dump({
             'format': 'bundle@1',
-            'manifest': {'tool': 'gitingest', 'tool_version': 'latest',
-              'generated_at': '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
-              'file_count': 0, 'byte_count': b, 'token_estimate': b // 4,
-              'format': 'plaintext'},
-            'content_url': f'https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/digest.txt'
-          }, open('digest.bundle.json', 'w'), indent=2)"
+            'manifest': {'tool': 'gitingest',
+              'generated_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+              'byte_count': b, 'token_estimate': b // 4, 'format': 'plaintext'},
+            'content_url': f'https://raw.githubusercontent.com/{repo}/{sha}/digest.txt'
+          }, open('digest.bundle.json', 'w'), indent=2)
+          PY
       - uses: looptech-ai/uq-publish-action@v0.1.0
         with:
           graph-path: digest.bundle.json
@@ -48,4 +65,5 @@ jobs:
 ## Notes
 
 - Submission is opt-in and gated entirely on the secret being set; without `UNDERSTAND_QUICKLY_TOKEN` the Action only stamps metadata locally and exits cleanly.
+- Only suitable for public repos (the digest is fetched from `raw.githubusercontent.com`).
 - See the [producer protocol](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md) for the full contract and [`DATA-LICENSE.md`](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) for the data-grant semantics.


### PR DESCRIPTION
## Why

[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public, machine-readable registry of code-knowledge and code-context artifacts. It indexes Gitingest digests through its [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format — a tiny JSON pointer plus a raw URL to the digest body — so AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its Gitingest digest. The registry stores no bodies; the digest stays in the user's repo and is fetched from `raw.githubusercontent.com`.

This PR is docs-only. It documents the opt-in workflow for Gitingest users who want their digest to land in the registry. No CLI changes, no runtime changes.

## What changes

- New file: `docs/publishing.md` — explains the registry, one-time setup, and a drop-in `.github/workflows/understand-quickly-publish.yml` snippet (~30 lines) that chains `gitingest` with the [`looptech-ai/uq-publish-action@v0.1.0`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action. The snippet builds a small bundle@1 sidecar (file size, generated_at, content_url) and hands it off to publish.
- `README.md`: a one-line pointer at the bottom of \"Command line usage\" linking to `docs/publishing.md`.

## Opt-in / no-op

Submission is gated entirely on the user setting `UNDERSTAND_QUICKLY_TOKEN` (a fine-grained PAT scoped to `looptech-ai/understand-quickly` only with `Repository dispatches: write`). Without the secret, the publish action only stamps metadata locally and exits cleanly. Without the workflow file, nothing changes.

## Why no CLI change

The flow is entirely orchestrated in Actions: Gitingest already emits `digest.txt`, the Marketplace Action builds the bundle@1 sidecar and posts the dispatch. Keeping the integration on the CI side means no new flag in the CLI surface, no test churn, and no behavior change for anyone not opting in.

## Test plan

- [x] Diff is docs-only (one new file at `docs/publishing.md`, two-line README pointer).
- [x] No tests touched, no `pyproject.toml` changes, no Python source touched.
- [ ] (Reviewer) Markdown renders cleanly on GitHub.

## Notes

- This is opt-in for early adopters; nothing in Gitingest's existing surface changes.
- License & data-grant semantics for users who opt in are described in [`DATA-LICENSE.md`](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) and [protocol §12](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#12-licensing-of-submitted-data) — opt-in, gated on the secret, never invisible.

## Links

- Registry: <https://github.com/looptech-ai/understand-quickly>
- Producer protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
- bundle@1 schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json>
- Marketplace Action: <https://github.com/looptech-ai/uq-publish-action>