### PR TITLE
feat: add digest restore mode to rebuild projects from digest.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ By default, the digest is written to a text file (`digest.txt`) in your current 
 - Use `--output/-o <filename>` to write to a specific file.
 - Use `--output/-o -` to output directly to `STDOUT` (useful for piping to other tools).
 
+You can also restore a project structure from an existing digest:
+
+```bash
+# Restore digest content into the current directory
+gitingest digest.txt --restore
+
+# Restore into a specific folder
+gitingest digest.txt --restore --restore-dir ./restored-project
+
+# Allow overwriting existing files during restore
+gitingest digest.txt --restore --restore-dir ./restored-project --overwrite
+```
+
 See more options and usage details with:
 
 ```bash

--- a/src/gitingest/__init__.py
+++ b/src/gitingest/__init__.py
@@ -1,5 +1,6 @@
 """Gitingest: A package for ingesting data from Git repositories."""
 
+from gitingest.digest import parse_digest, restore_digest
 from gitingest.entrypoint import ingest, ingest_async
 
-__all__ = ["ingest", "ingest_async"]
+__all__ = ["ingest", "ingest_async", "parse_digest", "restore_digest"]

--- a/src/gitingest/__main__.py
+++ b/src/gitingest/__main__.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import TypedDict
 
 import click
 from typing_extensions import Unpack
 
 from gitingest.config import MAX_FILE_SIZE, OUTPUT_FILE_NAME
+from gitingest.digest import restore_digest
 from gitingest.entrypoint import ingest_async
 
 # Import logging configuration first to intercept all logging
@@ -29,6 +31,9 @@ class _CLIArgs(TypedDict):
     include_submodules: bool
     token: str | None
     output: str | None
+    restore: bool
+    restore_dir: str
+    overwrite: bool
 
 
 @click.command()
@@ -75,6 +80,24 @@ class _CLIArgs(TypedDict):
     "-o",
     default=None,
     help="Output file path (default: digest.txt in current directory). Use '-' for stdout.",
+)
+@click.option(
+    "--restore",
+    is_flag=True,
+    default=False,
+    help="Restore a project from a digest file instead of generating one.",
+)
+@click.option(
+    "--restore-dir",
+    default=".",
+    show_default=True,
+    help="Destination directory used with --restore.",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Allow overwriting files when restoring from digest.",
 )
 def main(**cli_kwargs: Unpack[_CLIArgs]) -> None:
     """Run the CLI entry point to analyze a repo / directory and dump its contents.
@@ -125,6 +148,9 @@ async def _async_main(
     include_submodules: bool = False,
     token: str | None = None,
     output: str | None = None,
+    restore: bool = False,
+    restore_dir: str = ".",
+    overwrite: bool = False,
 ) -> None:
     """Analyze a directory or repository and create a text dump of its contents.
 
@@ -161,6 +187,28 @@ async def _async_main(
         Raised if an error occurs during execution and the command must be aborted.
 
     """
+    if restore:
+        try:
+            digest_path = Path(source)
+            restored_files, restored_symlinks, restored_directories = restore_digest(
+                digest_path=digest_path,
+                destination=restore_dir,
+                overwrite=overwrite,
+            )
+        except Exception as exc:
+            click.echo(f"Error: {exc}", err=True)
+            raise click.Abort from exc
+
+        click.echo(
+            (
+                "Restore complete! "
+                f"Recreated {restored_files} files, "
+                f"{restored_directories} directories, "
+                f"and {restored_symlinks} symlinks in '{restore_dir}'."
+            ),
+        )
+        return
+
     try:
         # Normalise pattern containers (the ingest layer expects sets)
         exclude_patterns = set(exclude_pattern) if exclude_pattern else set()

--- a/src/gitingest/digest.py
+++ b/src/gitingest/digest.py
@@ -1,0 +1,167 @@
+"""Utilities for restoring a project from a gitingest digest file."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from gitingest.schemas.filesystem import SEPARATOR
+
+_BLOCK_HEADER_RE = re.compile(r"^(FILE|SYMLINK): (.+?)(?: -> (.+))?$")
+
+
+@dataclass
+class DigestEntry:
+    """A single digest block for a file or symlink."""
+
+    entry_type: str
+    relative_path: str
+    content: str
+    symlink_target: str | None = None
+
+
+def parse_digest(text: str) -> list[DigestEntry]:
+    """Parse digest text and return all file/symlink entries in order."""
+    entries: list[DigestEntry] = []
+    position = 0
+
+    while True:
+        block = _find_block(text, position)
+        if block is None:
+            break
+
+        start, content_start, entry_type, relative_path, symlink_target = block
+        next_start = _find_next_block_start(text, content_start)
+        if next_start is None:
+            raw_content = text[content_start:]
+            position = len(text)
+            content = _trim_synthetic_suffix(raw_content, inter_block=False)
+        else:
+            raw_content = text[content_start:next_start]
+            position = next_start
+            content = _trim_synthetic_suffix(raw_content, inter_block=True)
+
+        entries.append(
+            DigestEntry(
+                entry_type=entry_type,
+                relative_path=relative_path,
+                content=content,
+                symlink_target=symlink_target,
+            ),
+        )
+
+    return entries
+
+
+def restore_digest(
+    digest_path: str | Path,
+    destination: str | Path,
+    *,
+    overwrite: bool = False,
+) -> tuple[int, int, int]:
+    """Restore files from ``digest_path`` into ``destination``.
+
+    Returns ``(restored_files, restored_symlinks, directories)``.
+    """
+    digest_file = Path(digest_path)
+    destination_dir = Path(destination)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    entries = parse_digest(digest_file.read_text(encoding="utf-8"))
+    if not entries:
+        msg = "No FILE or SYMLINK entries were found in the digest."
+        raise ValueError(msg)
+
+    restored_files = 0
+    restored_symlinks = 0
+    restored_directories: set[Path] = set()
+    for entry in entries:
+        output_path = _safe_join(destination_dir, entry.relative_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if output_path.parent != destination_dir:
+            restored_directories.add(output_path.parent)
+
+        if entry.entry_type == "FILE":
+            _write_file(output_path, entry.content, overwrite=overwrite)
+            restored_files += 1
+        elif entry.entry_type == "SYMLINK":
+            _write_symlink(output_path, entry.symlink_target, overwrite=overwrite)
+            restored_symlinks += 1
+
+    return restored_files, restored_symlinks, len(restored_directories)
+
+
+def _find_block(text: str, start: int) -> tuple[int, int, str, str, str | None] | None:
+    marker = f"{SEPARATOR}\n"
+    idx = text.find(marker, start)
+    while idx != -1:
+        header_start = idx + len(marker)
+        header_end = text.find("\n", header_start)
+        if header_end == -1:
+            return None
+
+        second_sep_start = header_end + 1
+        second_marker = f"{SEPARATOR}\n"
+        if not text.startswith(second_marker, second_sep_start):
+            idx = text.find(marker, header_start)
+            continue
+
+        header = text[header_start:header_end]
+        match = _BLOCK_HEADER_RE.match(header)
+        if match is None:
+            idx = text.find(marker, header_start)
+            continue
+
+        content_start = second_sep_start + len(second_marker)
+        return idx, content_start, match.group(1), match.group(2), match.group(3)
+
+    return None
+
+
+def _find_next_block_start(text: str, start: int) -> int | None:
+    marker = f"\n{SEPARATOR}\n"
+    idx = text.find(marker, start)
+    while idx != -1:
+        candidate = _find_block(text, idx + 1)
+        if candidate and candidate[0] == idx + 1:
+            return idx
+        idx = text.find(marker, idx + 1)
+    return None
+
+
+def _trim_synthetic_suffix(content: str, *, inter_block: bool) -> str:
+    if inter_block and content.endswith("\n\n\n"):
+        return content[:-3]
+    if content.endswith("\n\n"):
+        return content[:-2]
+    return content
+
+
+def _safe_join(base_dir: Path, relative_path: str) -> Path:
+    output_path = (base_dir / relative_path).resolve()
+    base_resolved = base_dir.resolve()
+    if output_path != base_resolved and base_resolved not in output_path.parents:
+        msg = f"Refusing to write outside destination directory: {relative_path}"
+        raise ValueError(msg)
+    return output_path
+
+
+def _write_file(path: Path, content: str, *, overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        msg = f"Refusing to overwrite existing path: {path}"
+        raise FileExistsError(msg)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_symlink(path: Path, target: str | None, *, overwrite: bool) -> None:
+    if not target:
+        msg = f"Invalid symlink entry for path: {path}"
+        raise ValueError(msg)
+
+    if path.exists() or path.is_symlink():
+        if not overwrite:
+            msg = f"Refusing to overwrite existing path: {path}"
+            raise FileExistsError(msg)
+        path.unlink()
+    path.symlink_to(target)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner, Result
 
 from gitingest.__main__ import main
 from gitingest.config import MAX_FILE_SIZE, OUTPUT_FILE_NAME
+from gitingest.schemas.filesystem import SEPARATOR
 
 
 @pytest.mark.parametrize(
@@ -97,3 +98,26 @@ def _invoke_isolated_cli_runner(args: list[str]) -> Result:
         kwargs["mix_stderr"] = False  # Click 8.0-8.1
     runner = CliRunner(**kwargs)
     return runner.invoke(main, args)
+
+
+def test_cli_restore_mode(tmp_path: Path) -> None:
+    """Restore mode should recreate files from a digest."""
+    digest_path = tmp_path / OUTPUT_FILE_NAME
+    digest_path.write_text(
+        (
+            f"{SEPARATOR}\n"
+            "FILE: src/hello.py\n"
+            f"{SEPARATOR}\n"
+            "print('hello')\n\n"
+        ),
+        encoding="utf-8",
+    )
+
+    restore_target = tmp_path / "restored"
+    result = _invoke_isolated_cli_runner(
+        [str(digest_path), "--restore", "--restore-dir", str(restore_target)],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "Recreated 1 files, 1 directories, and 0 symlinks" in result.stdout
+    assert (restore_target / "src" / "hello.py").read_text(encoding="utf-8") == "print('hello')"

--- a/tests/test_digest_restore.py
+++ b/tests/test_digest_restore.py
@@ -1,0 +1,84 @@
+"""Tests for digest parsing and project restoration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gitingest.digest import parse_digest, restore_digest
+from gitingest.schemas.filesystem import SEPARATOR
+
+
+def test_parse_digest_extracts_file_and_symlink_entries() -> None:
+    """It should parse FILE and SYMLINK blocks from digest text."""
+    digest_text = (
+        f"Directory structure:\n"
+        f"└── sample/\n\n"
+        f"{SEPARATOR}\n"
+        "FILE: src/main.py\n"
+        f"{SEPARATOR}\n"
+        "print('hello')\n\n\n"
+        f"{SEPARATOR}\n"
+        "SYMLINK: src/latest.py -> main.py\n"
+        f"{SEPARATOR}\n"
+        "\n\n"
+    )
+
+    entries = parse_digest(digest_text)
+
+    assert len(entries) == 2
+    assert entries[0].entry_type == "FILE"
+    assert entries[0].relative_path == "src/main.py"
+    assert entries[0].content == "print('hello')"
+    assert entries[1].entry_type == "SYMLINK"
+    assert entries[1].relative_path == "src/latest.py"
+    assert entries[1].symlink_target == "main.py"
+
+
+def test_restore_digest_creates_project_files(tmp_path: Path) -> None:
+    """It should recreate files and symlinks from a digest file."""
+    digest_path = tmp_path / "digest.txt"
+    digest_path.write_text(
+        (
+            f"{SEPARATOR}\n"
+            "FILE: app.py\n"
+            f"{SEPARATOR}\n"
+            "print('ok')\n\n\n"
+            f"{SEPARATOR}\n"
+            "FILE: nested/config.txt\n"
+            f"{SEPARATOR}\n"
+            "ENV=dev\n\n\n"
+            f"{SEPARATOR}\n"
+            "SYMLINK: nested/latest.txt -> config.txt\n"
+            f"{SEPARATOR}\n"
+            "\n\n"
+        ),
+        encoding="utf-8",
+    )
+
+    files, symlinks, directories = restore_digest(digest_path=digest_path, destination=tmp_path / "restored")
+
+    assert files == 2
+    assert symlinks == 1
+    assert directories == 1
+    assert (tmp_path / "restored" / "app.py").read_text(encoding="utf-8") == "print('ok')"
+    assert (tmp_path / "restored" / "nested" / "config.txt").read_text(encoding="utf-8") == "ENV=dev"
+    assert (tmp_path / "restored" / "nested" / "latest.txt").is_symlink()
+
+
+def test_restore_digest_rejects_path_traversal(tmp_path: Path) -> None:
+    """It should reject digest entries that escape the destination path."""
+    digest_path = tmp_path / "digest.txt"
+    digest_path.write_text(
+        (
+            f"{SEPARATOR}\n"
+            "FILE: ../escape.txt\n"
+            f"{SEPARATOR}\n"
+            "escaped\n\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="outside destination directory"):
+        restore_digest(digest_path=digest_path, destination=tmp_path / "restored")


### PR DESCRIPTION
## Summary

This PR adds reverse-ingestion support so users can reconstruct a project from an existing `digest.txt`.

### What’s included
- Added a new restore module to parse digest blocks (`FILE:` / `SYMLINK:`) and rebuild files.
- Added CLI restore mode:
  - `--restore`
  - `--restore-dir`
  - `--overwrite`
- Added safety guard to prevent path traversal (e.g. `../` escaping destination).
- Added restore completion stats in CLI output:
  - number of files
  - number of directories
  - number of symlinks
- Added tests for parsing, restore behavior, CLI flow, and traversal protection.
- Updated README with restore usage examples.

## Why

`gitingest` already converts repositories into prompt-ready digests.  
This change enables the reverse workflow: digest back to runnable project structure.

## Usage examples

```bash
# Restore into current directory
gitingest digest.txt --restore

# Restore into a specific folder
gitingest digest.txt --restore --restore-dir ./restored-project

# Overwrite existing files
gitingest digest.txt --restore --restore-dir ./restored-project --overwrite