### PR TITLE
fix: resolve URLs that start with gitingest.com

### DIFF
--- a/src/gitingest/utils/query_parser_utils.py
+++ b/src/gitingest/utils/query_parser_utils.py
@@ -83,12 +83,16 @@ async def _normalise_source(raw: str, token: str | None) -> ParseResult:
 
     if parsed.scheme:
         _validate_url_scheme(parsed.scheme)
+        if parsed.netloc.lower() == "gitingest.com":
+            return await _normalise_source(parsed.path.lstrip("/"), token)
         _validate_host(parsed.netloc)
         return parsed
 
     # no scheme ('host/user/repo' or 'user/repo')
     host = raw.split("/", 1)[0].lower()
     if "." in host:
+        if host == "gitingest.com":
+            return await _normalise_source(raw.split("/", 1)[1], token)
         _validate_host(host)
         return urlparse(f"https://{raw}")
 

--- a/tests/query_parser/test_query_parser.py
+++ b/tests/query_parser/test_query_parser.py
@@ -251,6 +251,33 @@ async def test_parse_url_with_query_and_fragment(stub_resolve_sha: dict[str, Asy
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("gitingest_url", "expected_url"),
+    [
+        ("https://gitingest.com/github.com/user/repo", "https://github.com/user/repo"),
+        ("gitingest.com/github.com/user/repo", "https://github.com/user/repo"),
+        ("https://gitingest.com/gitlab.com/user/repo", "https://gitlab.com/user/repo"),
+    ],
+)
+async def test_parse_url_gitingest_prefix(
+    gitingest_url: str,
+    expected_url: str,
+    stub_resolve_sha: dict[str, AsyncMock],
+) -> None:
+    """Test that gitingest.com URLs are unwrapped to their underlying git host URL.
+
+    Given a URL like "https://gitingest.com/github.com/user/repo":
+    When ``parse_remote_repo`` is called,
+    Then the gitingest.com prefix should be stripped and the repo resolved from the real host.
+    """
+    query = await parse_remote_repo(gitingest_url)
+
+    assert query.user_name == "user"
+    assert query.repo_name == "repo"
+    assert query.url == expected_url
+
+
+@pytest.mark.asyncio
 async def test_parse_url_unsupported_host(stub_resolve_sha: dict[str, AsyncMock]) -> None:
     """Test ``parse_remote_repo`` with an unsupported host.
 


### PR DESCRIPTION
## Summary

- Users sometimes copy-paste the gitingest.com URL (e.g. `https://gitingest.com/github.com/user/repo`) back into the input form, which previously raised `Unknown domain 'gitingest.com' in URL`
- Added detection in `_normalise_source` to strip the `gitingest.com` host and re-parse the remaining path, routing it to the real underlying git host
- Handles both the scheme form (`https://gitingest.com/...`) and the scheme-less form (`gitingest.com/...`)

## Changes

- **`src/gitingest/utils/query_parser_utils.py`**: In `_normalise_source`, detect `gitingest.com` as host and recurse with the path stripped of the prefix
- **`tests/query_parser/test_query_parser.py`**: Add `test_parse_url_gitingest_prefix` parametrized over three URL variants

## Test plan

- [x] New test `test_parse_url_gitingest_prefix` covers `https://gitingest.com/github.com/...`, `gitingest.com/github.com/...`, and `https://gitingest.com/gitlab.com/...`
- [x] Confirmed tests failed before the fix and pass after
- [x] Full `tests/query_parser/test_query_parser.py` suite passes (42/42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)