### PR TITLE
fix: handle utf-8 chunk boundary detection

### DIFF
--- a/src/gitingest/utils/file_utils.py
+++ b/src/gitingest/utils/file_utils.py
@@ -15,6 +15,7 @@ except locale.Error:
     locale.setlocale(locale.LC_ALL, "C")
 
 _CHUNK_SIZE = 1024  # bytes
+_MAX_PARTIAL_CHARACTER_BYTES = 4
 
 
 def _get_preferred_encodings() -> list[str]:
@@ -72,6 +73,6 @@ def _decodes(chunk: bytes, encoding: str) -> bool:
     """
     try:
         chunk.decode(encoding)
-    except UnicodeDecodeError:
-        return False
+    except UnicodeDecodeError as exc:
+        return exc.reason == "unexpected end of data" and len(chunk) - exc.start <= _MAX_PARTIAL_CHARACTER_BYTES
     return True

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,33 @@
+"""Tests for filesystem node content handling."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gitingest.schemas import FileSystemNode, FileSystemNodeType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_content_keeps_utf8_text_when_multibyte_character_crosses_chunk_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preserve UTF-8 text when a chunk ends inside a multibyte character."""
+    file_path = tmp_path / "boundary.py"
+    content = f"{'a' * 1023}漢\n"
+    file_path.write_text(content, encoding="utf-8")
+    monkeypatch.setattr("gitingest.schemas.filesystem._get_preferred_encodings", lambda: ["utf-8"])
+
+    node = FileSystemNode(
+        name=file_path.name,
+        type=FileSystemNodeType.FILE,
+        path_str=file_path.name,
+        path=file_path,
+        size=file_path.stat().st_size,
+    )
+
+    assert node.content == content


### PR DESCRIPTION
## Summary

- Fixes #578 by treating a UTF-8 sample chunk ending inside a multibyte character as text instead of binary.
- Keeps the change limited to the existing decode heuristic; full file reading and output formatting are unchanged.
- Adds a regression test for a 1024-byte boundary that splits a 3-byte UTF-8 character.

## Test plan

- RED: `python -m pytest tests/test_filesystem.py::test_content_keeps_utf8_text_when_multibyte_character_crosses_chunk_boundary -q`
  - Before the fix: failed because `node.content` returned `[Binary file]`.
- GREEN: `python -m pytest tests/test_filesystem.py::test_content_keeps_utf8_text_when_multibyte_character_crosses_chunk_boundary -q`
  - After the fix: `1 passed`.
- `python -m pytest tests/test_filesystem.py tests/test_ingestion.py -q`
  - `9 passed`.
- `python -m ruff check src/gitingest/utils/file_utils.py tests/test_filesystem.py`
  - `All checks passed!`.
- `python -m ruff format --check src/gitingest/utils/file_utils.py tests/test_filesystem.py`
  - `2 files already formatted`.
- `python -m pytest -q -k "not bitbucket"`
  - `154 passed, 7 deselected`.

Note: full `python -m pytest -q` currently fails on three Bitbucket-hosted `tests/query_parser/test_git_host_agnostic.py` cases because `git ls-remote https://bitbucket.org/na-dna/llm-knowledge-share HEAD` prompts for credentials in this non-interactive environment (`fatal: could not read Username for 'https://bitbucket.org'`). The failure is outside this file-content decoding path.