### PR TITLE
fix: respect include patterns for directory symlinks

### DIFF
--- a/src/gitingest/utils/ingestion_utils.py
+++ b/src/gitingest/utils/ingestion_utils.py
@@ -33,7 +33,7 @@ def _should_include(path: Path, base_path: Path, include_patterns: set[str]) -> 
     rel_path = _relative_or_none(path, base_path)
     if rel_path is None:  # outside repo → do *not* include
         return False
-    if path.is_dir():  # keep directories so children are visited
+    if path.is_dir() and not path.is_symlink():  # keep directories so children are visited
         return True
 
     spec = PathSpec.from_lines("gitwildmatch", include_patterns)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -11,7 +11,9 @@ from typing import TYPE_CHECKING, TypedDict
 
 import pytest
 
+from gitingest import output_formatter
 from gitingest.ingestion import ingest_query
+from gitingest.schemas import filesystem
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -233,3 +235,47 @@ def test_include_ignore_patterns(
     # check non-presence of non-included directories in structure
     for expected_not_structure_item in pattern_scenario["expected_not_structure"]:
         assert expected_not_structure_item not in structure
+
+
+def test_include_pattern_excludes_symlink_to_directory(
+    temp_directory: Path,
+    sample_query: IngestionQuery,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify directory symlinks are filtered by include patterns."""
+    real_dir = temp_directory / "real_dir"
+    real_dir.mkdir()
+    (real_dir / "real_file.txt").write_text("real content")
+
+    symlink_path = temp_directory / "should_exclude_me"
+    try:
+        symlink_path.symlink_to(real_dir, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        symlink_path.mkdir()
+        # Fall back to simulating a directory symlink on platforms that require symlink privileges.
+        original_is_symlink = type(symlink_path).is_symlink
+
+        def fake_is_symlink(self: Path) -> bool:
+            return self == symlink_path or original_is_symlink(self)
+
+        original_readlink = output_formatter.readlink
+
+        def fake_readlink(path: Path) -> Path:
+            if path == symlink_path:
+                return real_dir
+            return original_readlink(path)
+
+        monkeypatch.setattr(type(symlink_path), "is_symlink", fake_is_symlink)
+        monkeypatch.setattr(output_formatter, "readlink", fake_readlink)
+        monkeypatch.setattr(filesystem, "readlink", fake_readlink)
+
+    sample_query.local_path = temp_directory
+    sample_query.subpath = "/"
+    sample_query.type = None
+    sample_query.include_patterns = {"real_dir/*"}
+
+    _, structure, content = ingest_query(sample_query)
+
+    assert "should_exclude_me" not in structure
+    assert "real_dir/" in structure
+    assert "real_dir/real_file.txt" in content


### PR DESCRIPTION
## Summary

Fix a bug where directory symlinks bypass include-pattern filtering.

When a symlink points to a directory, `Path.is_dir()` follows the link and returns `True`. The `_should_include()` directory shortcut therefore accepted such symlinks before checking whether the symlink path matched the user's include patterns.

## Root cause

`src/gitingest/utils/ingestion_utils.py` used this shortcut so normal directories are still traversed while looking for matching descendants:

```python
if path.is_dir():
    return True
```

Because `Path.is_dir()` follows symlinks, a symlink pointing to a directory was treated like a regular directory and skipped the include-pattern match entirely.

## Changes

- Added a `not path.is_symlink()` guard to `_should_include()`'s directory shortcut.
- Added a regression test covering a directory symlink whose own path does not match the include pattern.

## Testing

- `uv run pytest tests/test_ingestion.py::test_include_pattern_excludes_symlink_to_directory -v --tb=short`
  - `1 passed, 110 warnings in 0.24s`
- `uv run pytest tests/test_ingestion.py -v --tb=short`
  - `9 passed, 470 warnings in 0.33s`
- `uv run pytest tests/ -v --tb=short --ignore=tests/query_parser/test_git_host_agnostic.py`
  - `140 passed, 63843 warnings in 165.57s (0:02:45)`
- `uv run --with ruff ruff check src/gitingest/utils/ingestion_utils.py tests/test_ingestion.py`
  - `All checks passed!`

Note: a full local `uv run pytest tests/ -v --tb=short` run does not currently complete in my environment because `tests/query_parser/test_git_host_agnostic.py` hits an external Bitbucket repository that returns `403`; I therefore ran the rest of the suite with that file ignored.

## Related issue

Fixes #585
