### PR TITLE
Change Docker image tag from latest to main

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -45,7 +45,7 @@ services:
   # Production service configuration
   app:
     <<: *app-base
-    image: ghcr.io/coderamp-labs/gitingest:latest
+    image: ghcr.io/coderamp-labs/gitingest:main
     profiles:
       - prod
     environment:


### PR DESCRIPTION
Fix: wrong docker image tag "latest" replaced by "main"