### PR TITLE
docs(readme): update Trendshift badge id 13519 -> 14818

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://github.com/coderamp-labs/gitingest"><img src="https://img.shields.io/github/stars/coderamp-labs/gitingest" alt="GitHub Stars"></a>
   <a href="https://discord.com/invite/zerRaGK9EC"><img src="https://img.shields.io/badge/Discord-Join_chat-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <br>
-  <a href="https://trendshift.io/repositories/13519"><img src="https://trendshift.io/api/badge/repositories/13519" alt="Trendshift" height="50"></a>
+  <a href="https://trendshift.io/repositories/14818"><img src="https://trendshift.io/api/badge/repositories/14818" alt="Trendshift" height="50"></a>
 </p>
 <!-- markdownlint-enable MD033 -->
 


### PR DESCRIPTION
The Trendshift repository ID in the badge link and image no longer resolves. The repository's current ID is `14818`. Update both the href and the img src so the badge renders and links correctly.

By the way, Trendshift.io doesn't delete repositories, but in this case a manual cleanup a few months ago, which handled GitHub renames removed the old row for a few repos 🙏 .