### PR TITLE
fix: fall back to root on an unrecognized URL path kind

### DIFF
--- a/src/gitingest/query_parser.py
+++ b/src/gitingest/query_parser.py
@@ -68,7 +68,17 @@ async def parse_remote_repo(source: str, token: str | None = None) -> IngestionQ
     if not path_parts:
         return await _fallback_to_root(query, token=token)
 
-    kind = PathKind(path_parts.pop(0))  # may raise ValueError
+    try:
+        kind = PathKind(path_parts[0])
+    except ValueError:
+        # An unrecognized path kind (e.g. /releases, /wiki, /actions, /commits)
+        # is not a tree/blob we can ingest. Fall back to the repository root
+        # instead of raising, matching how the known-but-unsupported kinds
+        # (issues, pull) are handled below.
+        msg = f"Warning: Unsupported path kind in {url}. Returning repository root."
+        return await _fallback_to_root(query, token=token, warn_msg=msg)
+
+    path_parts.pop(0)
     query.type = kind
 
     # TODO: Handle issues and pull requests

--- a/tests/query_parser/test_query_parser.py
+++ b/tests/query_parser/test_query_parser.py
@@ -219,6 +219,26 @@ async def test_parse_url_branch_and_commit_distinction(
     assert _is_valid_git_commit_hash(query.commit)
 
 
+@pytest.mark.asyncio
+async def test_parse_url_unsupported_path_kind_falls_back_to_root(
+    stub_resolve_sha: dict[str, AsyncMock],
+) -> None:
+    """Test ``parse_remote_repo`` with an unrecognized path kind.
+
+    Given a valid repository URL whose path kind is not tree/blob/issues/pull
+    (e.g. ".../releases/tag/v1.0"):
+    When ``parse_remote_repo`` is called,
+    Then it should fall back to the repository root instead of raising ValueError.
+    """
+    url = DEMO_URL + "/releases/tag/v1.0"
+
+    query = await parse_remote_repo(url)
+
+    assert query.user_name == "user"
+    assert query.repo_name == "repo"
+    assert query.commit is not None
+
+
 async def test_parse_local_dir_path_uuid_uniqueness() -> None:
     """Test ``parse_local_dir_path`` for unique UUID generation.
 


### PR DESCRIPTION
`parse_remote_repo` crashes on valid GitHub URLs whose path kind is not `tree`/`blob`/`issues`/`pull`:

```python
from gitingest import ingest
ingest("https://github.com/user/repo/releases/tag/v1.0")
# ValueError: 'releases' is not a valid PathKind
```

The line `kind = PathKind(path_parts.pop(0))` raises `ValueError` for any unrecognized segment, and `ingest_async` calls `parse_remote_repo` without catching it, so the whole ingest fails. Common URLs a user might paste hit this: `/releases/...`, `/wiki`, `/actions`, `/commits/main`, `/security`, etc.

It is also inconsistent: the known-but-unsupported kinds (`issues`, `pull`) already fall back to the repository root with a warning, but an unknown kind crashes instead.

This catches the `ValueError` and falls back to root the same way, so those URLs ingest the repository root instead of erroring. Added a regression test; the full `query_parser` suite passes (40 tests).