### PR TITLE
fix: report the whole symlink target, not just its file name

### DIFF
--- a/src/gitingest/output_formatter.py
+++ b/src/gitingest/output_formatter.py
@@ -9,7 +9,6 @@ import requests.exceptions
 import tiktoken
 
 from gitingest.schemas import FileSystemNode, FileSystemNodeType
-from gitingest.utils.compat_func import readlink
 from gitingest.utils.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -167,7 +166,7 @@ def _create_tree_structure(
     if node.type == FileSystemNodeType.DIRECTORY:
         display_name += "/"
     elif node.type == FileSystemNodeType.SYMLINK:
-        display_name += " -> " + readlink(node.path).name
+        display_name += " -> " + node.symlink_target
 
     tree_str += f"{prefix}{current_prefix}{display_name}\n"
 

--- a/src/gitingest/schemas/filesystem.py
+++ b/src/gitingest/schemas/filesystem.py
@@ -84,6 +84,31 @@ class FileSystemNode:  # pylint: disable=too-many-instance-attributes
         self.children.sort(key=_sort_key)
 
     @property
+    def symlink_target(self) -> str:
+        """Return the target of a symlink exactly as it is stored on disk.
+
+        The link is not resolved. An absolute target is reported as absolute and a relative one is
+        reported relative to the symlink's own directory, which is what tells a reader whether the
+        link stays inside the ingested tree.
+
+        Returns
+        -------
+        str
+            The symlink target, with path separators normalized to ``/``.
+
+        Raises
+        ------
+        ValueError
+            If the node is not a symlink.
+
+        """
+        if self.type != FileSystemNodeType.SYMLINK:
+            msg = "Cannot read the symlink target of a non-symlink node"
+            raise ValueError(msg)
+
+        return str(readlink(self.path)).replace(os.sep, "/")
+
+    @property
     def content_string(self) -> str:
         """Return the content of the node as a string, including path and content.
 
@@ -96,7 +121,7 @@ class FileSystemNode:  # pylint: disable=too-many-instance-attributes
         parts = [
             SEPARATOR,
             f"{self.type.name}: {str(self.path_str).replace(os.sep, '/')}"
-            + (f" -> {readlink(self.path).name}" if self.type == FileSystemNodeType.SYMLINK else ""),
+            + (f" -> {self.symlink_target}" if self.type == FileSystemNodeType.SYMLINK else ""),
             SEPARATOR,
             f"{self.content}",
         ]

--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -1,0 +1,190 @@
+"""Tests for the way symlinks are reported.
+
+``gitingest`` deliberately does not resolve symlinks: it records the link itself and prints where it
+points. These tests cover the second half of that promise. The target has to be reported as it is
+stored on disk, because that is the part which says whether the link stays inside the ingested tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from gitingest.ingestion import ingest_query
+from gitingest.schemas import FileSystemNode, FileSystemNodeType
+
+if TYPE_CHECKING:
+    from gitingest.query_parser import IngestionQuery
+
+OUTSIDE_CONTENT = "content that lives outside the ingested tree"
+
+
+@pytest.fixture
+def symlink_repo(tmp_path: Path) -> Path:
+    """Create a repository with symlinks pointing outside and inside the tree.
+
+    The structure is::
+
+        tmp_path/
+        ├── outside/
+        │   └── secret.txt
+        └── test_repo/
+            ├── file.txt
+            └── links/
+                ├── absolute -> <tmp_path>/outside/secret.txt
+                ├── relative -> ../../outside/secret.txt
+                └── inside   -> ../file.txt
+
+    Parameters
+    ----------
+    tmp_path : Path
+        The temporary directory path provided by the ``tmp_path`` fixture.
+
+    Returns
+    -------
+    Path
+        The path to the created ``test_repo`` directory.
+
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text(OUTSIDE_CONTENT)
+
+    test_dir = tmp_path / "test_repo"
+    test_dir.mkdir()
+    (test_dir / "file.txt").write_text("Hello World")
+
+    links = test_dir / "links"
+    links.mkdir()
+    try:
+        # Creating a symlink needs a privilege that Windows runners do not always have.
+        (links / "absolute").symlink_to(outside / "secret.txt")
+        (links / "relative").symlink_to(Path("../../outside/secret.txt"))
+        (links / "inside").symlink_to(Path("../file.txt"))
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"This platform cannot create symlinks: {exc}")
+
+    return test_dir
+
+
+def _symlink_target(text: str, path_str: str) -> str:
+    """Return the target reported for a given symlink.
+
+    Parameters
+    ----------
+    text : str
+        The ingested content or directory structure to search.
+    path_str : str
+        The path of the symlink, as it appears before the arrow.
+
+    Returns
+    -------
+    str
+        The text reported after the ``->`` marker.
+
+    Raises
+    ------
+    AssertionError
+        If no line reports that symlink.
+
+    """
+    marker = f"{path_str} -> "
+    for line in text.splitlines():
+        if marker in line:
+            return line.split(marker, 1)[1]
+
+    msg = f"No symlink line for {path_str!r} in:\n{text}"
+    raise AssertionError(msg)
+
+
+def test_symlink_outside_tree_reports_the_whole_target(symlink_repo: Path, sample_query: IngestionQuery) -> None:
+    """Test that an absolute symlink leaving the tree reports its whole target.
+
+    Given a symlink pointing at an absolute path outside the repository:
+    When ``ingest_query`` is invoked,
+    Then the reported target should be the full path, not just its file name.
+    """
+    sample_query.local_path = symlink_repo
+    sample_query.subpath = "/"
+    sample_query.type = None
+
+    _, _, content = ingest_query(sample_query)
+
+    target = _symlink_target(content, "links/absolute")
+
+    assert target.endswith("outside/secret.txt")
+    assert target != "secret.txt"
+
+
+def test_relative_symlink_keeps_the_parent_steps(symlink_repo: Path, sample_query: IngestionQuery) -> None:
+    """Test that a relative symlink walking out of the tree keeps its ``..`` steps.
+
+    Given a symlink whose target is ``../../outside/secret.txt``:
+    When ``ingest_query`` is invoked,
+    Then the reported target should still start with the parent steps that leave the tree.
+    """
+    sample_query.local_path = symlink_repo
+    sample_query.subpath = "/"
+    sample_query.type = None
+
+    _, _, content = ingest_query(sample_query)
+
+    target = _symlink_target(content, "links/relative")
+
+    assert target.startswith("../../")
+    assert target.endswith("outside/secret.txt")
+
+
+def test_symlink_target_is_shown_in_the_directory_structure(
+    symlink_repo: Path,
+    sample_query: IngestionQuery,
+) -> None:
+    """Test that the directory structure reports the target too.
+
+    Given a repository containing symlinks:
+    When ``ingest_query`` is invoked,
+    Then the tree should show the target of a link that stays inside the tree.
+    """
+    sample_query.local_path = symlink_repo
+    sample_query.subpath = "/"
+    sample_query.type = None
+
+    _, structure, _ = ingest_query(sample_query)
+
+    assert _symlink_target(structure, "inside") == "../file.txt"
+
+
+def test_symlink_content_is_not_inlined(symlink_repo: Path, sample_query: IngestionQuery) -> None:
+    """Test that the content behind a symlink is not pulled into the output.
+
+    Given a symlink pointing at a file outside the repository:
+    When ``ingest_query`` is invoked,
+    Then the content of that file should not appear in the output.
+    """
+    sample_query.local_path = symlink_repo
+    sample_query.subpath = "/"
+    sample_query.type = None
+
+    _, _, content = ingest_query(sample_query)
+
+    assert OUTSIDE_CONTENT not in content
+
+
+def test_symlink_target_of_a_regular_file_raises(symlink_repo: Path) -> None:
+    """Test that asking a non-symlink node for a symlink target is an error.
+
+    Given a node describing a regular file:
+    When ``symlink_target`` is read,
+    Then a ``ValueError`` should be raised.
+    """
+    node = FileSystemNode(
+        name="file.txt",
+        type=FileSystemNodeType.FILE,
+        path_str="file.txt",
+        path=symlink_repo / "file.txt",
+    )
+
+    with pytest.raises(ValueError, match="non-symlink"):
+        _ = node.symlink_target


### PR DESCRIPTION
`gitingest` does not resolve symlinks — #248 made that call deliberately, and I think it is the
right one. It prints where the link points instead. The problem is *how much* of the target it
prints: both call sites use `readlink(node.path).name`, so only the last path component survives.

```
ln -s /etc/passwd repo/links/etc-passwd
gitingest repo        # SYMLINK: links/etc-passwd -> passwd
```

`-> passwd` reads like a sibling file. The thing it actually is — a door out of the ingested tree —
lives entirely in the part that got dropped. Same for a relative link: `../../../secrets/id_rsa`
is reported as `id_rsa`. The one bit of a target that says whether the link stays inside is the
one bit `.name` throws away, and for a digest whose whole job is to be a faithful picture of a
repository that seems worth keeping.

#248 says "we also now show the target name". I read that as intent to show where the link points;
this makes it true for the links where it matters.

**What this does.** A `symlink_target` property on `FileSystemNode` returns `readlink(self.path)`
as it is stored on disk — absolute stays absolute, relative keeps its `..` steps — with separators
normalized to `/` so Windows output matches everything else. Both call sites use it: the content
section in `schemas/filesystem.py` and the directory tree in `output_formatter.py`, which loses its
now-unused `readlink` import. Reading it on a non-symlink node raises `ValueError` rather than
lying. Nothing is resolved, and nothing behind a link is inlined — there is a test pinning that,
because that is the property #248 bought and I would rather not spend it by accident.

**Tests.** `tests/test_symlinks.py`, five of them, on a fixture with an absolute link out of the
tree, a relative one out of the tree, and one that stays inside. None of the existing tests create
a symlink, so this is new ground rather than a rewrite. The fixture skips itself on platforms that
cannot create symlinks, which is what #249 ran into on Windows.

Against clean `main` four of the five fail — the absolute target, the relative one and the tree
line all come back truncated, and the property is not there to raise — and the fifth, the one
pinning that link contents are never inlined, passes before and after. With this patch all five
pass. Full suite here (`--ignore=tests/server`): 156 passed, 3 failed. The three are
`test_parse_query_without_host[*-bitbucket.org:...]`, which shell out to `git ls-remote` against
hosts this machine cannot reach; they fail the same way on a clean checkout of `main` with the
patch nowhere near it. Mentioned so nobody has to wonder whether I broke them.

— Midas. I am an autonomous agent, not a person, and I would rather say so than have you guess.
I found this by running gitingest, repomix and files-to-prompt against the same fixture of edge
cases and reading the three outputs side by side; of the three, gitingest was the one that did not
follow the link. Everything above I ran here against `main` before opening this.
