### PR TITLE
fix(notebook): handle plain-string outputs in _extract_output

### DIFF
--- a/src/gitingest/utils/notebook.py
+++ b/src/gitingest/utils/notebook.py
@@ -147,10 +147,12 @@ def _extract_output(output: dict[str, Any]) -> list[str]:
     output_type = output["output_type"]
 
     if output_type == "stream":
-        return output["text"]
+        text = output["text"]
+        return text.splitlines() if isinstance(text, str) else text
 
     if output_type in ("execute_result", "display_data"):
-        return output["data"]["text/plain"]
+        text = output["data"]["text/plain"]
+        return text.splitlines() if isinstance(text, str) else text
 
     if output_type == "error":
         return [f"Error: {output['ename']}: {output['evalue']}"]

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -268,3 +268,40 @@ def test_process_notebook_with_output(write_notebook: WriteNotebookFunc) -> None
 
     assert with_output == expected_combined, "Should include source code and comment-ified output."
     assert without_output == expected_source, "Should include only the source code without output."
+
+
+def test_process_notebook_string_form_output(write_notebook: WriteNotebookFunc) -> None:
+    """Test that plain-string outputs (schema-valid) don't explode into one-character-per-line garbage."""
+    notebook_content = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "outputs": [
+                    # Schema-valid string forms (nbformat v4 allows both str and list-of-str)
+                    {"output_type": "stream", "name": "stdout", "text": "hello world"},
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/plain": "42"},
+                        "metadata": {},
+                    },
+                    # Multi-line string form must split into lines like the list form does
+                    {"output_type": "stream", "name": "stdout", "text": "line1\nline2"},
+                ],
+                "source": ["print('hello world')"],
+            },
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+    nb_path = write_notebook("string_form.ipynb", notebook_content)
+    result = process_notebook(nb_path, include_output=True)
+
+    assert "#   hello world" in result, "String-form stream output should stay on one line"
+    assert "#   42" in result, "String-form execute_result output should stay on one line"
+    assert "#   line1\n#   line2" in result, "Multi-line string output should split lines like the list form"
+    assert "#   h\n" not in result, "No single-character lines (the bug's signature)"


### PR DESCRIPTION
## Summary

Converts the fix offered in #603 into a reviewable PR.

`process_notebook` corrupts cell outputs into one-character-per-line garbage whenever an output stores its text as a **plain string** rather than a list of strings — which the nbformat v4 schema explicitly allows for both `stream.text` and `output.data["text/plain"]` (the schema permits `string | array of strings` for multiline vs single-line storage).

A normal output like `hello world` currently renders as:

```
# Output:
#   h
#   e
#   l
#   l
#   o
#    
#   w
#   o
#   r
#   l
#   d
```

burning tokens and destroying readability for any notebook produced by a tool that serializes single-line outputs as strings (common in programmatic notebook generation and some exporter paths).

## Root cause

`_extract_output` in `src/gitingest/utils/notebook.py` returned the raw value. The caller (`_process_cell`) then does `raw_lines += _extract_output(output)` — when the value is a `str`, `list.__iadd__` iterates **characters**, and each character becomes its own `#   `-prefixed line. `cell["source"]` in the same file already handles both forms correctly, so `_extract_output` was the only unguarded site.

## Fix

Coerce the string form via `splitlines()` in both branches. This also restores correct rendering for multi-line string-form outputs, matching the list-form behavior line-for-line.

## Verification

- Reproduced on stock `main` (4e259a0): string-form stream + execute_result outputs explode into per-character lines (regression test fails with the exact signature below).
- With the fix: both render as `#   hello world` / `#   42` on single lines; multi-line string form splits correctly.
- New regression test `test_process_notebook_string_form_output` in `tests/test_notebook_utils.py` — proven RED on stock (stash control) and GREEN with the patch.
- Full local suite: `152 passed` (151 stock + this test). The only failures anywhere are 3 pre-existing network-dependent bitbucket cases in `test_git_host_agnostic.py` that fail identically on unpatched stock (verified via stash control).
- `ruff check` parity with stock (no new findings; the 2 CPY001 copyright notices are pre-existing on both trees).

Fixes #603

---

*Context: I run [FreshContext](https://deploy-foorge-team.vercel.app/) — a $5 pack that keeps AI coding agents off stale docs and deprecated patterns. Recently credited in [llm-docs-builder v1.0.0](https://github.com/mensfeld/llm-docs-builder/issues/165) for a similar LLM-pipeline correctness fix, and have a merged fix in [cloudflare-docs#32985](https://github.com/cloudflare/cloudflare-docs/pull/32985).*
